### PR TITLE
Feature/new database migration for meet dates

### DIFF
--- a/app/Models/Date.php
+++ b/app/Models/Date.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Date extends Model
+{
+    use HasFactory;
+
+    protected $table = 'dates';
+
+    protected $fillable = ['date_and_time', 'voted_by'];
+    public function meeting(): BelongsTo
+    {
+        return $this->belongsTo(Meeting::class, 'meeting_id', 'id');
+    }
+}

--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Ramsey\Uuid\Uuid;
 
 class Meeting extends Model
@@ -19,7 +20,7 @@ class Meeting extends Model
     public $incrementing = false;
     protected $keyType = 'string';
 
-    protected static function boot()
+    protected static function boot(): void
     {
         parent::boot();
 
@@ -31,5 +32,10 @@ class Meeting extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function dates(): HasMany
+    {
+        return $this->hasMany(Date::class);
     }
 }

--- a/database/factories/DateFactory.php
+++ b/database/factories/DateFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Date;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+class DateFactory extends Factory
+{
+    protected $model = Date::class;
+
+    public function definition(): array
+    {
+        return [
+            'date_and_time' => Carbon::now(),
+            'voted_by' => $this->faker->word(),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ];
+    }
+}

--- a/database/factories/MeetingFactory.php
+++ b/database/factories/MeetingFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Meeting;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+use Ramsey\Uuid\Uuid;
+
+class MeetingFactory extends Factory
+{
+    protected $model = Meeting::class;
+
+    public function definition(): array
+    {
+        return [
+            'id' => Uuid::uuid4()->toString(), // Generate UUID for the primary key
+            'user_id' => function () {
+                return User::factory()->create()->id;
+            },
+            'title' => $this->faker->sentence,
+            'description' => $this->faker->paragraph,
+            'location' => $this->faker->address,
+            'timezone' => 0,
+            'duration' => 30,
+            'meet_times' => json_encode([]),
+            'delete_after' => 90,
+        ];
+    }
+}

--- a/database/migrations/2023_07_18_112505_create_meetings_table.php
+++ b/database/migrations/2023_07_18_112505_create_meetings_table.php
@@ -23,9 +23,9 @@ return new class extends Migration
             $table->string('location')->default('Not specified');
             $table->smallInteger('timezone')->default('0');
             $table->smallInteger('duration')->default('30');
-            $table->integer('meet_times')->default('{}');
+            $table->json('meet_times')->default(json_encode([]));
             $table->integer('delete_after')->default('90');
-            $table->timestamps();            
+            $table->timestamps();
         });
     }
 

--- a/database/migrations/2023_07_20_083956_create_dates_table.php
+++ b/database/migrations/2023_07_20_083956_create_dates_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Read more about these migrations in docs/feature-docs/new-database-migration-for-meet-dates.md
+     */
+    public function up(): void
+    {
+        Schema::create('dates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('meeting_id')->constrained('meetings')->onDelete('cascade');
+            $table->dateTime('date_and_time');
+            $table->string('voted_by')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('dates');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Models\Meeting;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -12,11 +13,11 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
+//        \App\Models\User::factory(10)->create();
+        Meeting::factory()
+            ->count(10)
+            ->hasDates(3)
+            ->create();
 
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
     }
 }

--- a/docs/feature-docs/new-database-migration-for-meet-dates.md
+++ b/docs/feature-docs/new-database-migration-for-meet-dates.md
@@ -1,0 +1,19 @@
+# Docs for a branch feature/new-database-migration-for-meet-dates
+
+Created Date.php model and added a BelongsTo relationship with meeting_id
+
+In Meeting.php model added a return type of void to boot function.
+Created has many relationship with Date model.
+
+Created Factories for dates and meetings to generate fake data. To run use ```php artisan db:seed```
+
+Added a call to factory from DatabaseSeeder.php
+
+Created a migration for dates table with data:
+1. id
+2. foreignId from meetings table meeting_id
+3. dateTime type date_and_time
+4. string voted_by
+
+Create phpunit feature test for meeting and dates relationships. First test to check if meeting dates can be retrieved and second to check if related dates are deleted on meeting deletion
+To run tests use ```php artisan test``` or press run from PhpStorm

--- a/tests/Feature/MeetingDateRelationshipTest.php
+++ b/tests/Feature/MeetingDateRelationshipTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Meeting;
+use App\Models\Date;
+
+class MeetingDateRelationshipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_can_retrieve_dates_for_a_meeting()
+    {
+        // Create a meeting and associate dates with it
+        $meeting = Meeting::factory()->create();
+        $meeting->dates()->createMany([
+            ['date_and_time' => '2023-07-20 14:00:00'],
+            ['date_and_time' => '2023-07-21 10:30:00'],
+            ['date_and_time' => '2023-07-22 16:15:00'],
+        ]);
+
+        // Retrieve the dates for the meeting
+        $dates = $meeting->dates;
+
+        // Assert that the relationship is working correctly
+        $this->assertCount(3, $dates);
+    }
+
+    /** @test */
+    public function it_can_cascade_delete_associated_dates_on_meeting_deletion()
+    {
+        // Create a meeting and associate dates with it
+        $meeting = Meeting::factory()->create();
+        $meeting->dates()->createMany([
+            ['date_and_time' => '2023-07-20 14:00:00'],
+            ['date_and_time' => '2023-07-21 10:30:00'],
+            ['date_and_time' => '2023-07-22 16:15:00'],
+        ]);
+
+        // Delete the meeting
+        $meeting->delete();
+
+        // Check if the associated dates are also deleted
+        $dates = Date::where('meeting_id', $meeting->id)->get();
+        $this->assertCount(0, $dates);
+    }
+}


### PR DESCRIPTION
Created docs/feature-docs directory for storing all branches docs. This will prevent branch docs from being lost when old branches are deleted

Created docs/feature-docs/new-database-migration-for-meet-dates.md

Created Date.php model and added a BelongsTo relationship with meeting_id

In Meeting.php model added a return type of void to boot function.
Created has many relationship with Date model.

Created Factories for dates and meetings to generate fake data. To run use ```php artisan db:seed```

Added a call to factory from DatabaseSeeder.php

Created a migration for dates table with data:
1. id
2. foreignId from meetings table meeting_id
3. dateTime type date_and_time
4. string voted_by

Create phpunit feature test for meeting and dates relationships. First test to check if meeting dates can be retrieved and second to check if related dates are deleted on meeting deletion
To run tests use ```php artisan test``` or press run from PhpStorm