### PR TITLE
Add Vote model and update the Database seed logic

### DIFF
--- a/app/Http/Requests/VoteRequest.php
+++ b/app/Http/Requests/VoteRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class VoteRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'voted_by' => ['nullable'],
+        ];
+    }
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+}

--- a/app/Models/Date.php
+++ b/app/Models/Date.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Date extends Model
 {
@@ -16,5 +17,10 @@ class Date extends Model
     public function meeting(): BelongsTo
     {
         return $this->belongsTo(Meeting::class, 'meeting_id', 'id');
+    }
+
+    public function votes(): HasMany
+    {
+        return $this->hasMany(Vote::class);
     }
 }

--- a/app/Models/Vote.php
+++ b/app/Models/Vote.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Vote extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'voted_by',
+    ];
+
+    public function date(): BelongsTo
+    {
+        return $this->belongsTo(Date::class);
+    }
+}

--- a/database/factories/DateFactory.php
+++ b/database/factories/DateFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Date;
+use App\Models\Meeting;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
 
@@ -13,8 +14,8 @@ class DateFactory extends Factory
     public function definition(): array
     {
         return [
-            'date_and_time' => Carbon::now(),
-            'voted_by' => $this->faker->name(),
+            'meeting_id' => Meeting::factory(),
+            'date_and_time' => $this->faker->dateTimeBetween('now', '+1 month'),
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
         ];

--- a/database/factories/VoteFactory.php
+++ b/database/factories/VoteFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Vote;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class VoteFactory extends Factory
+{
+    protected $model = Vote::class;
+
+    public function definition(): array
+    {
+        return [
+            'voted_by' => $this->faker->name(),
+        ];
+    }
+}

--- a/database/migrations/2023_07_20_083956_create_dates_table.php
+++ b/database/migrations/2023_07_20_083956_create_dates_table.php
@@ -15,7 +15,6 @@ return new class extends Migration
             $table->id();
             $table->foreignId('meeting_id')->constrained('meetings')->onDelete('cascade');
             $table->dateTime('date_and_time');
-            $table->string('voted_by')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_07_24_223715_create_votes_table.php
+++ b/database/migrations/2023_07_24_223715_create_votes_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('votes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('date_id')->constrained('dates')->onDelete('cascade');
+            $table->string('voted_by')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('votes');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,7 +3,9 @@
 namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Models\Date;
 use App\Models\Meeting;
+use App\Models\Vote;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -14,8 +16,10 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         Meeting::factory()
-            ->count(10)
-            ->hasDates(3)
+            ->has(Date::factory()
+                ->count(5)
+                ->has(Vote::factory()->count(3))
+            )
             ->create();
     }
 }


### PR DESCRIPTION
Added a new Vote model and made changes to the voting system. As 'voted_by' is now part of the Vote model, it is removed from the Date model. A hasMany relationship was added in the Date model to reflect the "one date has many votes" relationship. The DateFactory now generates random future dates and corresponds Votes to these dates rather than using the current time. The update in DatabaseSeeder changes how Dates and associated Votes are seeded, meaning that now each Meeting will have 5 Dates and each Date will have 3 Votes. This improves the database seeding performance and data representation.
![Database Scheme](https://github.com/kibernetiku-klubas/timely/assets/64190545/dce581da-d7bf-43ff-b901-6cdff00c3bfc)
