### PR TITLE
Add success notification for meeting creation

### DIFF
--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -24,7 +24,7 @@ class MeetingController extends Controller
         $meeting->delete_after = $validated['delete_after'];
         $meeting->save();
 
-        return redirect('/dashboard');
+        return redirect('/dashboard')->with('success', 'Meeting created successfully');
     }
 
     public function show($id)

--- a/resources/views/components/notification.blade.php
+++ b/resources/views/components/notification.blade.php
@@ -1,0 +1,29 @@
+<div>
+    <div class="alert-container">
+        <div class="flex justify-center text-black bg-white px-4 py-3 rounded-lg shadow-xl relative max-w-lg mx-auto mt-6 p-6">
+            <strong class="font-bold">{{ session()->get('success') }}</strong>
+        </div>
+    </div>
+
+        <style>
+            .alert-container {
+                opacity: 1;
+                transition: opacity 0.3s ease-out;
+            }
+
+            .alert-container.fade-out {
+                opacity: 0;
+            }
+        </style>
+
+        <script>
+            setTimeout(function () {
+                let alertContainer = document.querySelector('.alert-container');
+                alertContainer.classList.add('fade-out');
+
+                setTimeout(function () {
+                    alertContainer.style.display = 'none';
+                }, 400);
+            }, 2000);
+        </script>
+</div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,4 +1,9 @@
 <x-app-layout>
+    @if(session()->has('success'))
+        <x-notification>
+        </x-notification>
+    @endif
+
     <div class="py-12">
         <div class="flex items-center justify-center">
         <a href="/add-meeting"><button class="btn btn-outline border-none bg-primary-content text-black text-xl shadow-xl p-8 content-center">Add a new meeting <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="currentColor" class="bi bi-plus" viewBox="0 0 16 16"> <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/> </svg></button></a>


### PR DESCRIPTION
This commit adds a success notification that is displayed to the user when a meeting is created successfully. This involves a change in the MeetingController to return a success message along with the redirect to the dashboard. A new notification component has been added to the views as well, which shows the success message and automatically fades out after 2 seconds. This component has been included in the dashboard view, making it only visible when a success session variable exists. The aim is to give users clear feedback when a meeting is successfully created.