### PR TITLE
Converted timezone_offset values to be string.

### DIFF
--- a/app/Http/Requests/StoreMeeting.php
+++ b/app/Http/Requests/StoreMeeting.php
@@ -26,7 +26,7 @@ class StoreMeeting extends FormRequest
             'title' => 'required|string|max:64',
             'description' => 'max:255',
             'location' => 'max:64',
-            'timezone_offset' => 'required|integer|max:13|gt:0',
+            'timezone_offset' => 'required',
             'duration' => 'integer|max:32000|gt:0',
             'delete_after' => 'integer|max:32000|gt:0',
         ];

--- a/resources/views/meetings/add.blade.php
+++ b/resources/views/meetings/add.blade.php
@@ -30,36 +30,36 @@
                 <x-input-label for="timezone_offset" :value="__('Timezone')" />
                 <select name = "timezone_offset" id="timezone_offset" type="string" class="border border-gray-300 text-gray-900 text-sm rounded-lg w-full p-2.5 bg-white">
                     <option selected disabled>Choose a timezone</option>
-                    <option value="0">(UTC) Dublin, Edinburgh, Lisbon, London</option>
-                    <option value="1">(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna</option>
-                    <option value="2">(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius</option>
-                    <option value="3">(UTC+03:00) Kaliningrad, Minsk</option>
-                    <option value="4">(UTC+04:00) Moscow, St. Petersburg, Volgograd</option>
-                    <option value="5">(UTC+05:00) Islamabad, Karachi</option>
-                    <option value="6">(UTC+06:00) Ekaterinburg</option>
-                    <option value="7">(UTC+07:00) Bangkok, Hanoi, Jakarta</option>
-                    <option value="8">(UTC+08:00) Beijing, Chongqing, Hong Kong, Urumqi</option>
-                    <option value="9">(UTC+09:00) Osaka, Sapporo, Tokyo</option>
-                    <option value="10">(UTC+10:00) Canberra, Melbourne, Sydney</option>
-                    <option value="11">(UTC+11:00) Solomon Is., New Caledonia</option>
-                    <option value="12">(UTC+12:00) Auckland, Wellington</option>
-                    <option value="13">(UTC+13:00) Samoa</option>
-                    <option value="-1">(UTC-01:00) Cape Verde Is.</option>
-                    <option value="-2">(UTC-02:00) Mid-Atlantic</option>
-                    <option value="-3">(UTC-03:00) Greenland</option>
-                    <option value="-4">(UTC-04:00) Georgetown, La Paz, Manaus, San Juan</option>
-                    <option value="-5">(UTC-05:00) Eastern Time (US & Canada)</option>
-                    <option value="-6">(UTC-06:00) Central Time (US & Canada)</option>
-                    <option value="-7">(UTC-07:00) Mountain Time (US & Canada)</option>
-                    <option value="-8">(UTC-08:00) Pacific Time (US & Canada)</option>
-                    <option value="-9">(UTC-09:00) Alaska</option>
-                    <option value="-10">(UTC-10:00) Hawaii</option>
-                    <option value="-11">(UTC-11:00) Coordinated Universal Time-11</option>
-                    <option value="-12">(UTC-12:00) International Date Line West</option>
+                    <option>(UTC) Dublin, Edinburgh, Lisbon, London</option>
+                    <option>(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna</option>
+                    <option>(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius</option>
+                    <option>(UTC+03:00) Kaliningrad, Minsk</option>
+                    <option>(UTC+04:00) Moscow, St. Petersburg, Volgograd</option>
+                    <option>(UTC+05:00) Islamabad, Karachi</option>
+                    <option>(UTC+06:00) Ekaterinburg</option>
+                    <option>(UTC+07:00) Bangkok, Hanoi, Jakarta</option>
+                    <option>(UTC+08:00) Beijing, Chongqing, Hong Kong, Urumqi</option>
+                    <option>(UTC+09:00) Osaka, Sapporo, Tokyo</option>
+                    <option>(UTC+10:00) Canberra, Melbourne, Sydney</option>
+                    <option>(UTC+11:00) Solomon Is., New Caledonia</option>
+                    <option>(UTC+12:00) Auckland, Wellington</option>
+                    <option>(UTC+13:00) Samoa</option>
+                    <option>(UTC-01:00) Cape Verde Is.</option>
+                    <option>(UTC-02:00) Mid-Atlantic</option>
+                    <option>(UTC-03:00) Greenland</option>
+                    <option>(UTC-04:00) Georgetown, La Paz, Manaus, San Juan</option>
+                    <option>(UTC-05:00) Eastern Time (US & Canada)</option>
+                    <option>(UTC-06:00) Central Time (US & Canada)</option>
+                    <option>(UTC-07:00) Mountain Time (US & Canada)</option>
+                    <option>(UTC-08:00) Pacific Time (US & Canada)</option>
+                    <option>(UTC-09:00) Alaska</option>
+                    <option>(UTC-10:00) Hawaii</option>
+                    <option>(UTC-11:00) Coordinated Universal Time-11</option>
+                    <option>(UTC-12:00) International Date Line West</option>
                 </select>
-                @error('timezone_offset')
-                    <p class="text-red-500 text-sm">{{ "Timezone must be selected." }}</p>
-                @enderror
+                @if ($errors->has('timezone_offset'))
+                    <p class="text-red-500 text-sm">{{ $errors->first('timezone_offset') }}</p>
+                @endif
             </div>
             <!-- Duration -->
             <div>

--- a/resources/views/meetings/add.blade.php
+++ b/resources/views/meetings/add.blade.php
@@ -57,9 +57,9 @@
                     <option>(UTC-11:00) Coordinated Universal Time-11</option>
                     <option>(UTC-12:00) International Date Line West</option>
                 </select>
-                @if ($errors->has('timezone_offset'))
-                    <p class="text-red-500 text-sm">{{ $errors->first('timezone_offset') }}</p>
-                @endif
+                @error('timezone_offset')
+                    <p class="text-red-500 text-sm">{{ "Timezone must be selected." }}</p>
+                @enderror
             </div>
             <!-- Duration -->
             <div>


### PR DESCRIPTION
Removed 'int', 'max' and 'gt' requirements from timezone_offset, since it is now a  string.
Was looking for a way to avoid repeating value and option names (looked very inefficient) until I realized you can just remove the value entirely. This causes the value to default to the option name. Yes, it is that simple. I have no clue why this isn't the first solution shown when googling it.