### PR TITLE
Update 'timezone_offset' field to 'timezone'

### DIFF
--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -19,7 +19,7 @@ class MeetingController extends Controller
         $meeting->title = $validated['title'];
         $meeting->description = $validated['description'];
         $meeting->location = $validated['location'];
-        $meeting->timezone_offset = $validated['timezone_offset'];
+        $meeting->timezone = $validated['timezone'];
         $meeting->duration = $validated['duration'];
         $meeting->delete_after = $validated['delete_after'];
         $meeting->save();

--- a/app/Http/Requests/StoreMeeting.php
+++ b/app/Http/Requests/StoreMeeting.php
@@ -26,7 +26,7 @@ class StoreMeeting extends FormRequest
             'title' => 'required|string|max:64',
             'description' => 'max:255',
             'location' => 'max:64',
-            'timezone_offset' => 'required',
+            'timezone' => 'required|string',
             'duration' => 'integer|max:32000|gt:0',
             'delete_after' => 'integer|max:32000|gt:0',
         ];

--- a/database/migrations/2023_07_18_112505_create_meetings_table.php
+++ b/database/migrations/2023_07_18_112505_create_meetings_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->string('title');
             $table->longText('description')->default('Just another meeting');
             $table->string('location')->default('Not specified');
-            $table->smallInteger('timezone_offset')->default('0');
+            $table->string('timezone');
             $table->smallInteger('duration')->default('30');
             $table->integer('delete_after')->default('90');
             $table->timestamps();

--- a/resources/views/meetings/add.blade.php
+++ b/resources/views/meetings/add.blade.php
@@ -27,8 +27,8 @@
             </div>
             <!-- Timezone -->
             <div>
-                <x-input-label for="timezone_offset" :value="__('Timezone')" />
-                <select name = "timezone_offset" id="timezone_offset" type="string" class="border border-gray-300 text-gray-900 text-sm rounded-lg w-full p-2.5 bg-white">
+                <x-input-label for="timezone" :value="__('Timezone')" />
+                <select name = "timezone" id="timezone" type="string" class="border border-gray-300 text-gray-900 text-sm rounded-lg w-full p-2.5 bg-white">
                     <option selected disabled>Choose a timezone</option>
                     <option>(UTC) Dublin, Edinburgh, Lisbon, London</option>
                     <option>(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna</option>
@@ -57,7 +57,7 @@
                     <option>(UTC-11:00) Coordinated Universal Time-11</option>
                     <option>(UTC-12:00) International Date Line West</option>
                 </select>
-                @error('timezone_offset')
+                @error('timezone')
                     <p class="text-red-500 text-sm">{{ "Timezone must be selected." }}</p>
                 @enderror
             </div>

--- a/resources/views/meetings/meeting.blade.php
+++ b/resources/views/meetings/meeting.blade.php
@@ -6,7 +6,7 @@ Description:
 {{$meeting->description}}<br>
 Location:
 {{$meeting->location}}<br>
-Timezone offset (h): {{$meeting->timezone_offset}}<br>
+Timezone: {{$meeting->timezone}}<br>
 Duration (min): {{$meeting->duration}}<br>
 Meeting link: <a href="">https://domain.com/{{$meeting->id}}</a><br>
 Created at: {{$meeting->created_at}}<br>


### PR DESCRIPTION
Changed all mentions of 'timezone_offset' to 'timezone' in code, as it is more accurate and self-explanatory. The previous term was misleading as it suggested an offset value, whereas we're storing the exact timezone string. Changes were made in add.blade.php, MeetingController.php, create_meetings_table.php migration, StoreMeeting.php request and, meeting.blade.php. The database schema, error handling statements, stored values and validation rules were updated accordingly.