### PR TITLE
Updated tests to work with timezone rename

### DIFF
--- a/database/factories/MeetingFactory.php
+++ b/database/factories/MeetingFactory.php
@@ -21,7 +21,7 @@ class MeetingFactory extends Factory
             'title' => $this->faker->sentence,
             'description' => $this->faker->paragraph,
             'location' => $this->faker->address,
-            'timezone_offset' => 0,
+            'timezone' => '(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius',
             'duration' => 30,
             'delete_after' => 90,
         ];

--- a/tests/Feature/MeetingTest.php
+++ b/tests/Feature/MeetingTest.php
@@ -19,7 +19,7 @@ class MeetingTest extends TestCase
             'title' => 'Test Meeting',
             'description' => 'This is a test meeting',
             'location' => 'Test Location',
-            'timezone_offset' => 2,
+            'timezone' => '(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius',
             'duration' => 60,
             'delete_after' => 30,
         ];
@@ -32,7 +32,7 @@ class MeetingTest extends TestCase
             'title' => $formData['title'],
             'description' => $formData['description'],
             'location' => $formData['location'],
-            'timezone_offset' => $formData['timezone_offset'],
+            'timezone' => $formData['timezone'],
             'duration' => $formData['duration'],
             'delete_after' => $formData['delete_after'],
         ]);
@@ -46,7 +46,7 @@ class MeetingTest extends TestCase
             // Missing 'title' field, which is required
             'description' => 'This is a test meeting',
             'location' => 'Test Location',
-            'timezone_offset' => 2,
+            'timezone' => '(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius',
             'duration' => 60,
             'delete_after' => 30,
         ];


### PR DESCRIPTION
In MeetingFactory.php renamed timezone_offset to timezone and changed the value to an actual timezone string. Did the same in MeetingTest.php.