### PR TITLE
"Implement voting restriction to prevent multiple votes from the same user"

### DIFF
--- a/app/Http/Controllers/VoteController.php
+++ b/app/Http/Controllers/VoteController.php
@@ -18,6 +18,10 @@ class VoteController extends Controller
             return redirect()->back()->with('error', 'Please select at least one option.');
         }
 
+        if (session()->has('voted_' . $meetingId)) {
+            return redirect()->back()->with('error', 'You have already voted for this meeting.');
+        }
+
         foreach ($dateIds as $dateId) {
             if (in_array($dateId, $votes)) {
                 Vote::create([
@@ -26,6 +30,8 @@ class VoteController extends Controller
                 ]);
             }
         }
+
+        session(['voted_' . $meetingId => true]);
 
         return redirect()->route('meeting.show', ['id' => $meetingId])->with('success', 'Votes saved successfully!');
     }

--- a/resources/views/meetings/meeting.blade.php
+++ b/resources/views/meetings/meeting.blade.php
@@ -22,11 +22,24 @@
             Created at: {{ $meeting->created_at }}<br>
             Updated at: {{ $meeting->updated_at }}<br>
 
-            <div class="text-right pr-16">
-                <button class="btn btn-outline border-none text-black text-xl shadow-black shadow-2xl hover:shadow-none"
+            @php
+                $hasVoted = session()->has('voted_' . $meeting->id);
+            @endphp
+
+            @if (!$hasVoted)
+                <div class="text-right pr-16">
+                    <button
+                        class="btn btn-outline border-none text-black text-xl shadow-black shadow-2xl hover:shadow-none"
                         onclick="votesModal.showModal()">Vote on times
-                </button>
-            </div>
+                    </button>
+                </div>
+            @else
+                <div class="text-right pr-16">
+                    <button class="btn btn-outline border-none text-black text-xl shadow-2xl" disabled="disabled">
+                        You have already voted
+                    </button>
+                </div>
+            @endif
             <dialog id="votesModal" class="modal">
                 <form method="POST" action="{{ route('vote.store') }}" class="modal-box bg-white shadow-2xl">
                     <a class="btn btn-circle btn-outline mb-4" onclick="document.getElementById('votesModal').close();">
@@ -40,8 +53,8 @@
                     <input type="hidden" name="meeting_id" value="{{ $meeting->id }}">
                     <h3 class="font-bold text-lg text-black">Check every time you want to vote on and enter your name to
                         save your votes</h3>
-                    <p class="py-4 text-black">Note: Name will be visible to everyone viewing this meeting</p>
-
+                    <p class="py-4 text-black">Note: Name will be visible to everyone viewing this meeting.<br>
+                        It is also recommended to use your real name so that meeting creator knows who voted.</p>
                     @if (count($meeting->dates) === 0)
                         <p class="text-red-700 text-xl font-bold flex justify-center mt-4">NO DATES AVAILABLE FOR
                             VOTING</p>


### PR DESCRIPTION
Added a check that prevents a user from voting on the same meeting multiple times. This is achieved by storing a boolean flag 'voted_meetingId' in the user session after they vote. If the flag exists, they are redirected with an error. On the front end, the voting button is disabled if the user has already voted. The only workaround I found was inspecting element, that changing the disabled button to onclick="votesModal.showModal()", then modal can be opened, but if user tries to save votes this way a check in VoteController.php gives already voted error, and does not save votes.

This solution is not perfect, as users can vote again by clearing cookies or reopening browser. But we assume that meeting creator will only count the votes of names that he knows and will delete other. Writing this also decided to add a message to modal- "It is also recommended to use your real name so that meeting creator knows who voted."