### PR TITLE
bug/title-broke-styling

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,3 +5,11 @@ import Alpine from 'alpinejs';
 window.Alpine = Alpine;
 
 Alpine.start();
+
+document.addEventListener('DOMContentLoaded', function() {
+    // Get the tab name from the page's data attribute (make sure to set this in your view files)
+    const pageTitle = document.body.dataset.pageTitle;
+  
+    // Set the document title dynamically based on the tab name
+    document.title = pageTitle ? `${pageTitle} • Timely` : 'Timely';
+  });

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,4 +1,5 @@
 <x-guest-layout>
+    <body data-page-title="Login"></body>
     <!-- Session Status -->
     <x-auth-session-status class="mb-4" :status="session('status')" />
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,4 +1,5 @@
 <x-guest-layout>
+    <body data-page-title="Register"></body>
     <form method="POST" action="{{ route('register') }}">
         @csrf
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,7 +1,5 @@
-<head>
-    <title>Dashboard • Timely</title>
-</head>
 <x-app-layout>
+    <body data-page-title="Dashboard"></body>
     @if(session()->has('success'))
         <x-notification type="success" message="{{ session()->get('success') }}" />
     @endif

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,7 +5,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Laravel') }}</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -5,8 +5,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Laravel') }}</title>
-
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />

--- a/resources/views/meetings/add.blade.php
+++ b/resources/views/meetings/add.blade.php
@@ -1,7 +1,5 @@
-<head>
-    <title>Add a meeting • Timely</title>
-</head>
 <x-app-layout>
+    <body data-page-title="Add a meeting"></body>
     <x-slot name="header">
         <h2 class="text-xl text-gray-800 leading-tight">
             Add a new meeting

--- a/resources/views/meetings/confirm-delete.blade.php
+++ b/resources/views/meetings/confirm-delete.blade.php
@@ -1,7 +1,5 @@
-<head>
-    <title>Confirm deletion • Timely</title>
-</head>
 <x-app-layout>
+    <body data-page-title="Confirm deletion"></body>
     <x-meet-form-layout>
         <form method="POST" action='{{ route('meetings.delete', $id = $meeting->id) }}'>
             @csrf

--- a/resources/views/meetings/edit.blade.php
+++ b/resources/views/meetings/edit.blade.php
@@ -1,7 +1,5 @@
-<head>
-    <title>Edit meeting • Timely</title>
-</head>
 <x-app-layout>
+    <body data-page-title="Edit meeting"></body>
     <x-slot name="header">
         <h2 class="text-xl text-gray-800 leading-tight">
             Add a new meeting

--- a/resources/views/meetings/meeting-cards.blade.php
+++ b/resources/views/meetings/meeting-cards.blade.php
@@ -47,10 +47,10 @@
                                     <x-primary-button id="closeDialog" onclick="closeModal()">
                                         Cancel
                                     </x-primary-button>
-                                    <buttom id="confirmDelete" class="ml-2 btn btn-error"
+                                    <button id="confirmDelete" class="ml-2 btn btn-error"
                                             onclick="confirmDelete()">
                                         Confirm Delete
-                                    </buttom>
+                                    </button>
                                 </div>
                             </div>
                         @endif

--- a/resources/views/meetings/meeting.blade.php
+++ b/resources/views/meetings/meeting.blade.php
@@ -1,8 +1,5 @@
-<head>
-    <title>{{$meeting->title}} • Timely</title>
-</head>
 <x-app-layout>
-
+    <body data-page-title={{$meeting->title}}></body>
     @if (session()->has('error'))
         <x-notification type="error" message="{{ session('error') }}"/>
     @endif

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,7 +1,5 @@
-<head>
-    <title>Profile • Timely</title>
-</head>
 <x-app-layout>
+    <body data-page-title="Profile"></body>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             {{ __('Profile') }}

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Timely</title>
+        <body data-page-title="Welcome!"></body>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">


### PR DESCRIPTION
Removed previous `<title></title>` parts since they interfered with the styling. Replaced them with JavaScript instead, which is located in `app/resources/js/app.js`. This allows for more dynamic titles, since now only the title has to be written to each view, without "•|-" and such. For this to work, I had to remove the `<title></title>` parts from `app.blade.php` and `guest.blade.php`.

It also assigns a default value of "Timely" if there is no title assigned in the view.

Also added title names to tabs I had previously forgotten, such as the login, register and default landing page.