### PR TITLE
Add vote editing and deleting functionality

### DIFF
--- a/app/Http/Controllers/VoteController.php
+++ b/app/Http/Controllers/VoteController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Vote;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class VoteController extends Controller
@@ -34,5 +35,26 @@ class VoteController extends Controller
         session(['voted_' . $meetingId => true]);
 
         return redirect()->route('meeting.show', ['id' => $meetingId])->with('success', 'Votes saved successfully!');
+    }
+
+
+    public function update(Request $request, $id): RedirectResponse
+    {
+        $vote = Vote::findOrFail($id);
+        $vote->voted_by = $request->input('voted_by');
+        $vote->save();
+
+        return redirect()->route('meeting.show', ['id' => $vote->date->meeting->id])
+            ->with('success', 'Vote updated successfully!');
+    }
+
+    public function destroy($id): RedirectResponse
+    {
+        $vote = Vote::findOrFail($id);
+        $meetingId = $vote->date->meeting->id;
+        $vote->delete();
+
+        return redirect()->route('meeting.show', ['id' => $meetingId])
+            ->with('success', 'Vote deleted successfully!');
     }
 }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,6 +1,3 @@
-<head>
-    <title>Dashboard • Timely</title>
-</head>
 <x-app-layout>
     @if(session()->has('success'))
         <x-notification type="success" message="{{ session()->get('success') }}" />

--- a/resources/views/meetings/edit-meeting-buttons.blade.php
+++ b/resources/views/meetings/edit-meeting-buttons.blade.php
@@ -1,6 +1,6 @@
 @if (Auth::check() && $meeting->user_id == Auth::User()->id)
     <a href='/meeting/{{ $meeting->id }}/edit'>
-        <button class='btn btn-warning shadow-xl'>Edit meeting</button>
+        <button class='btn btn-warning shadow-xl'>Edit meeting and votes</button>
     </a>
     <a href='/meeting/{{ $meeting->id }}/delete'>
         <button class='btn btn-error shadow-xl'>Delete meeting</button>

--- a/resources/views/meetings/edit-votes.blade.php
+++ b/resources/views/meetings/edit-votes.blade.php
@@ -1,0 +1,32 @@
+<details class="collapse bg-white shadow-xl">
+    <summary class="collapse-title text-xl text-black font-medium">Edit votes:</summary>
+    <div class="collapse-content">
+        <div>Select a time to edit votes:</div>
+        @foreach($meeting->dates as $date)
+            <details class="collapse bg-white border-2">
+                <summary class="collapse-title text-xl text-black font-medium">Date and Time: {{ $date->date_and_time }}</summary>
+                <div class="collapse-content">
+                    @foreach($date->votes as $vote)
+                        <div class="border-2 border-black">
+                            <form method="post" action="{{ route('vote.update', $vote->id) }}">
+                                @csrf
+                                @method('put')
+                                <label for="voted_by_{{ $vote->id }}">Edit Vote Name:</label>
+                                <input type="text" name="voted_by" id="voted_by_{{ $vote->id }}" value="{{ $vote->voted_by }}"
+                                       required>
+                                <button type="submit" class="btn btn-success">Save</button>
+                            </form>
+                            <form method="post" action="{{ route('vote.destroy', $vote->id) }}">
+                                @csrf
+                                @method('delete')
+                                <button type="submit" class="btn btn-error">Delete</button>
+                            </form>
+                        </div>
+                    @endforeach
+                </div>
+            </details>
+
+        @endforeach
+    </div>
+</details>
+

--- a/resources/views/meetings/edit.blade.php
+++ b/resources/views/meetings/edit.blade.php
@@ -99,6 +99,7 @@
                 </x-primary-button>
             </div>
         </form>
+        @include('meetings.edit-votes')
     </x-meet-form-layout>
 </x-app-layout>
 

--- a/resources/views/meetings/meeting.blade.php
+++ b/resources/views/meetings/meeting.blade.php
@@ -1,6 +1,3 @@
-<head>
-    <title>{{$meeting->title}} • Timely</title>
-</head>
 <x-app-layout>
 
     @if (session()->has('error'))

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,9 @@ Route::middleware('auth')->group(function () {
     Route::delete('/meeting/{id}/delete', [MeetingController::class, 'destroy'])->name('meetings.delete');
     Route::get('/meeting/{id}/edit', [MeetingController::class, 'displayEdit']);
     Route::patch('/meeting/{id}/edit', [MeetingController::class, 'update'])->name('meetings.update');
+    Route::put('/vote/{id}', [VoteController::class, 'update'])->name('vote.update');
+    Route::delete('/vote/{id}', [VoteController::class, 'destroy'])->name('vote.destroy');
+
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
This commit introduces the ability to edit and delete individual votes within the meeting edit page. A new blade template 'edit-votes.blade.php' has been added to facilitate this, along with new update and delete methods in the VoteController. Additionally, the 'Edit meeting' button text has been updated to 'Edit meeting and votes' to reflect the new functionality. The relevant routes have also been updated in 'web.php'. List of changed files also includes changes in the 'edit.blade.php', 'dashboard.blade.php' and 'meeting.blade.php'. Removed unnecessary title tags from 'dashboard.blade.php' and 'meeting.blade.php'. Votes editing and deleting styling will be updated.

Also need feedback to decide where votes updating should redirect. Either to back to meeting page or back to editing form, where we will add a button to go back to meeting page (cancel editing button).