### PR TITLE
Limit character input on voter's name field

### DIFF
--- a/resources/views/meetings/vote.blade.php
+++ b/resources/views/meetings/vote.blade.php
@@ -38,7 +38,7 @@
             <div>
                 <x-input-label for="voted_by" :value="__('Your name')"/>
                 <x-text-input id="voted_by" class="block mt-1 w-full text-black" type="text" name="voted_by"
-                              :value="old('voted_by')" required autofocus/>
+                              :value="old('voted_by')" required autofocus maxlength="50" />
                 <x-input-error :messages="$errors->get('votes')" class="mt-2 text-red-700"/>
             </div>
             @foreach($meeting->dates as $date)


### PR DESCRIPTION
In the voting view, a maxlength attribute of 50 was added to the 'voted_by' text input field. This was done to prevent users from entering excessively long names, which could disrupt the layout or exceed database field limits.