### PR TITLE
bug/only-first-word-shown-in-tab

### DIFF
--- a/resources/views/meetings/meeting.blade.php
+++ b/resources/views/meetings/meeting.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
 
-    <body data-page-title={{$meeting->title}}></body>
+    <body data-page-title="{{$meeting->title}}"></body>
     @if (session()->has('error'))
         <x-notification type="error" message="{{ session('error') }}"/>
     @endif


### PR DESCRIPTION
Added quotes to `{{$meeting->title}}`. Yes. The fix was that simple. What happened was the dynamic meeting title was treated as an attribute, rather than string. And if more than one word was passed, they'd be treated as separate attributes. Only the first attribute would be read, which is why only one word appeared. Now the whole variable is treated as a string, and is passed as a whole.