### PR TITLE
Added checks that convert the submitted usernames to lowercase.

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -31,12 +31,18 @@ class RegisteredUserController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'name' => ['required', 'string', 'max:255', 'unique:'.User::class],
+            'name' => ['required', 'string', 'max:255', 'unique:users,name,' . strtolower($request->input('name'))],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
+        $lowercaseName = strtolower($request->input('name'));
+
+        if (User::where('name', $lowercaseName)->exists()) {
+            return redirect()->back()->withErrors(['name' => 'This name is already taken. Please choose a different one.']);
+        }
+
         $user = User::create([
-            'name' => $request->name,
+            'name' => $lowercaseName,
             'password' => Hash::make($request->password),
         ]);
 

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -41,7 +41,7 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        if (! Auth::attempt($this->only('name', 'password'), $this->boolean('remember'))) {
+        if (! Auth::attempt([ 'name' => strtolower($this->input('name')), 'password' => $this->password ], $this->boolean('remember'))) {
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -18,7 +18,7 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
+            'name' => fake()->username(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),
         ];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -8,7 +8,7 @@
 
         <div>
             <x-input-label for="name" :value="__('USERNAME')" />
-            <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
+            <x-text-input id="name" class="block mt-1 w-full lowercase" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -6,7 +6,7 @@
         <!-- Name -->
         <div>
             <x-input-label for="name" :value="__('USERNAME')" />
-            <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
+            <x-text-input id="name" class="block mt-1 w-full lowercase" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
 

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -21,9 +21,9 @@ class AuthenticationTest extends TestCase
     public function test_users_can_authenticate_using_the_login_screen(): void
     {
         $user = User::factory()->create();
-
+        
         $response = $this->post('/login', [
-            'name' => $user->name,
+            'name' => strtolower($user->name),
             'password' => 'password',
         ]);
 
@@ -36,7 +36,7 @@ class AuthenticationTest extends TestCase
         $user = User::factory()->create();
 
         $this->post('/login', [
-            'name' => $user->name,
+            'name' => strtolower($user->name),
             'password' => 'wrong-password',
         ]);
 


### PR DESCRIPTION
Functions changed:
`app/Http/Controllers/Auth/RegisteredUserController.php`
- store()

`app/Http/Requests/Auth/LoginRequest.php`
- authenticate()

In short:
- Added unreliable checks in the login/registration forms where the inputs are displayed in lowercase (but still passes on uppercase values)
- Added checks in login and registration validation functions, so that the names are always lowercased first before creation/auth'ing of accounts