### PR TITLE
Change 'name' autocomplete attribute in auth views to 'username'

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -8,7 +8,7 @@
 
         <div>
             <x-input-label for="name" :value="__('USERNAME')" />
-            <x-text-input id="name" class="block mt-1 w-full lowercase" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
+            <x-text-input id="name" class="block mt-1 w-full lowercase" type="text" name="name" :value="old('name')" required autofocus autocomplete="username" />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -6,7 +6,7 @@
         <!-- Name -->
         <div>
             <x-input-label for="name" :value="__('USERNAME')" />
-            <x-text-input id="name" class="block mt-1 w-full lowercase" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
+            <x-text-input id="name" class="block mt-1 w-full lowercase" type="text" name="name" :value="old('name')" required autofocus autocomplete="username" />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
 


### PR DESCRIPTION
Changed the autocomplete attribute from 'name' to 'username' in both login and register blade files. Since browsers don't autofill names, change to username now autofills from your browsers saved logins