### PR TITLE
feature/delete-meetings-after-selected-time

### DIFF
--- a/app/Console/Commands/DeleteExpiredMeetings.php
+++ b/app/Console/Commands/DeleteExpiredMeetings.php
@@ -14,7 +14,7 @@ class DeleteExpiredMeetings extends Command
 
     public function handle()
     {
-        $now = now();
+        $now = now()->addDay(); // adds one day to the current one using carbon, to prevent accidental deletion due to timezone differences
         Meeting::where(DB::raw("DATE(created_at, '+' || delete_after || ' day')"), '<', $now)->delete();
         $this->info('Expired meetings deleted successfully.');
     }

--- a/app/Console/Commands/DeleteExpiredMeetings.php
+++ b/app/Console/Commands/DeleteExpiredMeetings.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Meeting;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class DeleteExpiredMeetings extends Command
+{
+    protected $signature = 'meetings:delete-expired';
+    protected $description = 'Deletes expired meetings';
+
+    public function handle()
+    {
+        $now = now();
+        Meeting::where(DB::raw("DATE(created_at, '+' || delete_after || ' day')"), '<', $now)->delete();
+        $this->info('Expired meetings deleted successfully.');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,6 +13,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule): void
     {
         // $schedule->command('inspire')->hourly();
+        $schedule->command('meetings:delete-expired')->daily();
     }
 
     /**

--- a/tests/Feature/DeleteExpiredMeetingsTest.php
+++ b/tests/Feature/DeleteExpiredMeetingsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Meeting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Date;
+use Tests\TestCase;
+
+class DeleteExpiredMeetingsTest extends TestCase
+{
+    public function testExpiredMeetingsAreDeleted()
+    {
+        // Creates a meeting that SHOULD be deleted (delete_after = 5 days)
+        Meeting::factory()->create([
+            'created_at' => now()->subDays(7), // Created 7 days ago
+            'delete_after' => 5,
+        ]);
+
+        // Creates a meeting that SHOULDN'T be deleted (delete_after = 10 days)
+        Meeting::factory()->create([
+            'created_at' => now()->subDays(3), // Created 3 days ago
+            'delete_after' => 10,
+        ]);
+
+        // Sets the current time to a specific date and time
+        Date::setTestNow(now()->subDays(1)->startOfDay()->addHours(12));
+
+        // Runs the scheduled task
+        Artisan::call('meetings:delete-expired');
+
+        // Check that the expired meeting is deleted
+        $this->assertDatabaseMissing('meetings', [
+            'delete_after' => 5,
+        ]);
+
+        // Check that the non-expired meeting still exists
+        $this->assertDatabaseHas('meetings', [
+            'delete_after' => 10,
+        ]);
+    }
+}

--- a/tests/Feature/MeetingTest.php
+++ b/tests/Feature/MeetingTest.php
@@ -19,7 +19,7 @@ class MeetingTest extends TestCase
             'title' => 'Test Meeting',
             'description' => 'This is a test meeting',
             'location' => 'Test Location',
-            'timezone' => '(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius',
+            'timezone' => 'Europe/Vilnius',
             'duration' => 60,
             'delete_after' => 30,
         ];
@@ -46,7 +46,7 @@ class MeetingTest extends TestCase
             // Missing 'title' field, which is required
             'description' => 'This is a test meeting',
             'location' => 'Test Location',
-            'timezone' => '(UTC+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius',
+            'timezone' => 'Europe/Vilnius',
             'duration' => 60,
             'delete_after' => 30,
         ];


### PR DESCRIPTION
I added the following:

A command called `app/Console/Commands/DeleteExpiredMeetings.php`. It adds the creation date and the `delete_after` value together in each meeting, and compares it to the current date. If the expiration is due, the meeting is then deleted.

A `$schedule` in `app/Console/Kernel.php`, which schedules the command to be executed daily. I chose this because the `delete_after` value represents days, so performing this command any more frequently isn't necessary.

A new test file to test the expired meeting deletion, titled `tests/Feature/DeleteExpiredMeetingsTest.php`. It creates two meetings, one that is expired and one that isn't. It then sets the current time, and calls the scheduled task. Finally, it checks if the expired meeting is deleted, and if the non-expired meeting is kept.

Finally, I adjusted the 'timezone' values in `tests/Feature/MeetingTest.php` to match the new timezone formatting. Should probably be a separate PR, but I figured the changes were too minor for it.

Screenshot visualizing the new test output:

![image](https://github.com/kibernetiku-klubas/timely/assets/129758495/50ed72a8-2191-4718-8310-b3fd3e1cc870)
