### PR TITLE
Add handling for 1v1 meetings and voting limits

### DIFF
--- a/database/migrations/2023_07_18_112505_create_meetings_table.php
+++ b/database/migrations/2023_07_18_112505_create_meetings_table.php
@@ -25,7 +25,7 @@ return new class extends Migration
             $table->string('timezone');
             $table->smallInteger('duration')->default('30');
             $table->integer('delete_after')->default('90');
-            $table->boolean('is1v1')->nullable();
+            $table->tinyInteger('is1v1')->default(0);;
             $table->timestamps();
         });
     }

--- a/resources/views/meetings/meeting-cards.blade.php
+++ b/resources/views/meetings/meeting-cards.blade.php
@@ -70,7 +70,6 @@
                 </details>
             </div>
 
-
         </li>
     @endforeach
 </ul>

--- a/resources/views/meetings/meeting.blade.php
+++ b/resources/views/meetings/meeting.blade.php
@@ -22,6 +22,11 @@
 
 
             <div class="flex justify-center text-xl mt-8 font-bold"> DATES AND TIMES FOR THE MEETING:</div>
+            <div class="flex justify-center text-xl mt-8">
+                @if($meeting->is1v1 == 1)
+                    Note: This meeting is 1 on 1, so only one vote per date is allowed.
+                @endif
+            </div>
 
             <div>
                 @if (Auth::check())

--- a/resources/views/meetings/vote.blade.php
+++ b/resources/views/meetings/vote.blade.php
@@ -1,15 +1,16 @@
 @php
     $hasVoted = session()->has('voted_' . $meeting->id);
 @endphp
+
 @if (!$hasVoted)
-        <button
-            class="btn btn-outline border-none text-black text-xl shadow-lg hover:shadow-none"
-            onclick="votesModal.showModal()">ADD YOUR VOTES
-        </button>
+    <button
+        class="btn btn-outline border-none text-black text-xl shadow-lg hover:shadow-none"
+        onclick="votesModal.showModal()">ADD YOUR VOTES
+    </button>
 @else
-        <button class="btn btn-outline border-none text-black text-xl shadow-2xl" disabled="disabled">
-            <div class="text-gray-700">You have already voted</div>
-        </button>
+    <button class="btn btn-outline border-none text-black text-xl shadow-2xl" disabled="disabled">
+        <div class="text-gray-700">You have already voted</div>
+    </button>
 @endif
 
 <dialog id="votesModal" class="modal">
@@ -48,10 +49,20 @@
                 <input type="hidden" name="date_ids[]" value="{{ $date->id }}">
                 <div class="form-control">
                     <label class="label cursor-pointer">
-                        <span class="label-text text-lg text-black font-bold">VOTE ON: {{$date->date_and_time}}</span>
+                            <span
+                                class="label-text text-lg text-black font-bold">VOTE ON: {{$date->date_and_time}}</span>
                         <div class="shadow-xl">
-                            <input type="checkbox" name="votes[]" value="{{ $date->id }}"
-                                   class="checkbox checkbox-lg checkbox-success">
+                            @php
+                                $isDateTaken = \App\Models\Vote::where('date_id', $date->id)->exists();
+                                $disableCheckbox = $meeting->is1v1 == 1 && $isDateTaken;
+                            @endphp
+                            @if ($disableCheckbox)
+                                <input type="checkbox" name="votes[]" value="{{ $date->id }}"
+                                       class="checkbox checkbox-lg checkbox-success" disabled>
+                            @else
+                                <input type="checkbox" name="votes[]" value="{{ $date->id }}"
+                                       class="checkbox checkbox-lg checkbox-success">
+                            @endif
                         </div>
                     </label>
                 </div>


### PR DESCRIPTION
  This commit adds a distinction for one-on-one meetings within the voting system. It provides restrictions and enhances UX considerations. The voting interface now responds to meetings marked as '1v1', limiting users to vote for only one option and disabling the option that is already taken. Messages informing this have been added to views. Also, a minor tweak has been introduced in the meeting table migration where 'is1v1' field's default value is now '0' and was changed from boolean to tiny int, because mysql does not support booleans.