### PR TITLE
Feature/add-an-option-to-finalize-a-meeting time

### DIFF
--- a/app/Http/Controllers/DateController.php
+++ b/app/Http/Controllers/DateController.php
@@ -7,7 +7,7 @@ use App\Models\Date;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Meeting;
-
+use \Illuminate\Http\Request;
 class DateController extends Controller
 {
 
@@ -29,11 +29,11 @@ class DateController extends Controller
 
     public function update(StoreDate $request, $id): RedirectResponse
     {
-        $validatedData = $request->validated();
         $date = Date::findOrFail($id);
         $meetingId = $date->meeting_id;
         if (Auth::check() && Meeting::where('user_id', Auth::user()->id)->exists($date->meeting_id)) {
-            $date->date_and_time = $validatedData['new_time'];
+            Date::where('meeting_id', $meetingId)->update(['selected' => 0]);
+            $date->selected = 1;
             $date->save();
         }
 
@@ -50,17 +50,4 @@ class DateController extends Controller
         }
         return redirect("/meetings/$meetingId")->with('error', 'Date deleted.');
     }
-    public function select($id)
-{
-    $date = Date::findOrFail($id);
-
-    // Get the meeting associated with the date
-    $meeting = $date->meeting;
-
-    // Update the selected value for all dates associated with the meeting
-    $meeting->dates()->update(['selected' => 0]);
-    $date->update(['selected' => 1]);
-
-    return response()->json(['message' => 'Date selected successfully']);
-}
 }

--- a/app/Http/Controllers/DateController.php
+++ b/app/Http/Controllers/DateController.php
@@ -50,4 +50,17 @@ class DateController extends Controller
         }
         return redirect("/meetings/$meetingId")->with('error', 'Date deleted.');
     }
+    public function select($id)
+{
+    $date = Date::findOrFail($id);
+
+    // Get the meeting associated with the date
+    $meeting = $date->meeting;
+
+    // Update the selected value for all dates associated with the meeting
+    $meeting->dates()->update(['selected' => 0]);
+    $date->update(['selected' => 1]);
+
+    return response()->json(['message' => 'Date selected successfully']);
+}
 }

--- a/app/Http/Controllers/DateController.php
+++ b/app/Http/Controllers/DateController.php
@@ -7,7 +7,6 @@ use App\Models\Date;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Meeting;
-use \Illuminate\Http\Request;
 class DateController extends Controller
 {
 

--- a/app/Http/Requests/StoreDate.php
+++ b/app/Http/Requests/StoreDate.php
@@ -23,31 +23,36 @@ class StoreDate extends FormRequest
      * @return array<string, ValidationRule|array|string>
      */
     public function rules(): array
-    {
-        $meetingId = $this->input('meeting_id');
-        $existingDatesCount = Date::where('meeting_id', $meetingId)->count();
+{
+    $meetingId = $this->input('meeting_id');
+    $existingDatesCount = Date::where('meeting_id', $meetingId)->count();
 
-        return [
-            'new_time' => [
-                'required',
-                function ($attribute, $value, $fail) use ($meetingId) {
-                    // checks if the date is equal in the same meeting
-                    $date = Date::where('meeting_id', $meetingId)->where('date_and_time', $value);
-                    if ($this->getMethod() === 'PUT') { // excludes updated date from being checked (for when date is kept as before)
-                        $date->where('id', '!=', $this->route('date'));
-                    }
-                    if ($date->count() > 0) {
-                        $fail('The selected date already exists for this meeting.');
-                    }
-                },
-                function ($attribute, $value, $fail) use ($existingDatesCount) {
-                    if ($existingDatesCount >= 20) {
-                        $fail('The maximum number of dates (20) has been reached for this meeting.');
-                    }
-                },
-            ],
+    $rules = [];
+
+    // Only apply the new_time validation if it's present in the request
+    if ($this->has('new_time')) {
+        $rules['new_time'] = [
+            'required',
+            function ($attribute, $value, $fail) use ($meetingId) {
+                // checks if the date is equal in the same meeting
+                $date = Date::where('meeting_id', $meetingId)->where('date_and_time', $value);
+                if ($this->getMethod() === 'PUT') { // excludes updated date from being checked (for when date is kept as before)
+                    $date->where('id', '!=', $this->route('date'));
+                }
+                if ($date->count() > 0) {
+                    $fail('The selected date already exists for this meeting.');
+                }
+            },
+            function ($attribute, $value, $fail) use ($existingDatesCount) {
+                if ($existingDatesCount >= 20) {
+                    $fail('The maximum number of dates (20) has been reached for this meeting.');
+                }
+            },
         ];
     }
+
+    return $rules;
+}
 
     public function messages(): array
     {

--- a/app/Models/Date.php
+++ b/app/Models/Date.php
@@ -13,7 +13,7 @@ class Date extends Model
 
     protected $table = 'dates';
 
-    protected $fillable = ['date_and_time', 'voted_by'];
+    protected $fillable = ['date_and_time', 'voted_by', 'selected'];
 
     public function meeting(): BelongsTo
     {

--- a/database/migrations/2023_07_20_083956_create_dates_table.php
+++ b/database/migrations/2023_07_20_083956_create_dates_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
             $table->foreignUuid('meeting_id')->constrained('meetings')->onDelete('cascade');
             $table->dateTime('date_and_time');
             $table->timestamps();
+            $table->tinyInteger('selected')->default(0);
         });
     }
 

--- a/resources/views/meetings/meeting-cards.blade.php
+++ b/resources/views/meetings/meeting-cards.blade.php
@@ -1,40 +1,47 @@
-@foreach ($datesGroupedByYear as $year => $dates)
+@foreach($datesGroupedByYear as $year => $dates)
     <div class="text-center mt-8 mb-4">
         <div class="divider">
             <h1 class="text-3xl font-bold">{{ $year }}</h1>
         </div>
     </div>
     <ul class="grid lg:grid-cols-3 sm:grid-cols-1 md:grid-cols-2 gap-2">
-        @foreach ($dates as $date)
-            <li class="p-6 shadow-xl rounded-lg">
-                <input type="hidden" name="meeting_id" value="{{ $meeting->id }}">
+        @foreach($dates as $date)
+        <li class="p-6 shadow-xl rounded-lg" data-date-id="{{ $date->id }}">
+            <form id="dateForm-{{ $date->id }}" method="POST" action="{{ route('dates.select', ['id' => $date->id]) }}">
+            </form>
+         
+                @csrf
+                <input type='hidden' name='meeting_id' value='{{$meeting->id}}'>
                 <div class="flex justify-between">
-                    @if ($date->votes->count() > 0 && $date->votes->count() === $highestVoteCount)
-                        <div class="badge badge-outline text-purple-500 outline-purple-500 mt-3">Most voted</div>
-                    @else
+                    @if($date->selected === 1)
+                        <div class="badge badge-outline text-red-500 outline-red-500 mt-3">Selected</div>
+                    @elseif($date->votes->count() === 0) <!-- Only show when not selected and no votes -->
                         <div class="badge badge-outline outline-none border-none mt-3"></div>
                     @endif
-
+                    @if($date->votes->count() > 0 && $date->votes->count() === $highestVoteCount)
+                        <div class="badge badge-outline text-purple-500 outline-purple-500 mt-3">Most voted</div>
+                    @endif
+                    
+                    <!-- Update chosen date -->
                     @if (Auth::check() && $user->id == $meeting->user_id)
                         <form id="deleteForm" method="POST" action="{{ route('dates.destroy', ['id' => $date->id]) }}">
                             @csrf
-                            @method('DELETE')
-                            <div class="dropdown">
-                                <label tabindex="0" class="btn m-1 bg-white rounded-full border-none hover:bg-gray-400">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="black"
-                                         class="bi bi-three-dots" viewBox="0 0 16 16">
-                                        <path
-                                            d="M3 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"/>
-                                    </svg>
-                                </label>
-                                <a id="openDialog" class="" onclick="openModal(event)">
-                                    <ul tabindex="0"
-                                        class="dropdown-content bg-gray-100 rounded-box p-4 hover:bg-gray-200">
-                                        Delete
-                                    </ul>
-                                </a>
-                            </div>
+                            @method('DELETE') 
                         </form>
+                        <div class="dropdown">
+                            <label tabindex="0" class="btn m-1 bg-white rounded-full border-none hover:bg-gray-400">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="black"
+                                     class="bi bi-three-dots" viewBox="0 0 16 16">
+                                    <path
+                                        d="M3 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"/>
+                                </svg>
+                            </label>
+                            <ul tabindex="0" class="dropdown-content bg-gray-100 rounded-box p-4 hover:bg-gray-200">
+                                <li><a href="#" id="openDialog" class="" onclick="openModal(event)">Delete</a></li>
+                                <button type="submit" class="assign-selected" data-date-id="{{ $date->id }}">Finalize</button>
+
+                            </ul>    
+                        </div>
                         <div id="overlay"
                              class="fixed hidden z-40 w-screen h-screen inset-0 bg-gray-900 bg-opacity-60"></div>
                         <div id="dialog"
@@ -44,7 +51,9 @@
                             <div class="flex justify-end">
                                 <x-secondary-button class="m-1" id="closeDialog" onclick="closeModal()">Cancel
                                 </x-secondary-button>
-                                <x-danger-button class="m-1" onclick="confirmDelete()">Confirm Delete</x-danger-button>
+                                <x-danger-button class="m-1" onclick="confirmDelete()">Confirm
+                                    Delete
+                                </x-danger-button>
                             </div>
                         </div>
                     @endif
@@ -53,13 +62,11 @@
                 @php
                     $formattedDate = date("M d", strtotime($date->date_and_time));
                     $endTime = $date->date_and_time->copy()->addMinutes($meeting->duration);
-                    $isDateTaken = \App\Models\Vote::where('date_id', $date->id)->exists();
                 @endphp
 
                 <div class="flex justify-center">
                     <div>
-                        <div class="text-3xl font-bold">{{ $date->date_and_time->format('D') }}.</div>
-                        <div class="text-4xl font-bold mb-4">{{ $formattedDate }}</div>
+                        <div class="text-4xl font-bold">{{ $formattedDate }}</div>
                         <div class="font-bold uppercase"><span
                                 class="text-5xl font-bold">{{ $date->date_and_time->format('H:i') }}</span></div>
                         <div class="font-bold uppercase"><span class="text-5xl">{{ $endTime->format('H:i') }}</span>
@@ -68,25 +75,17 @@
                 </div>
 
                 <div class="font-bold text-xl flex justify-center mt-4"></div>
-                <div class="flex justify-center text-black text-3xl font-bold">
-                    @if ($meeting->is1v1 === 0)
-                        Votes: {{ $date->votes->count() }}
-                    @elseif ($meeting->is1v1 === 1 && $isDateTaken)
-                        TAKEN.
-                    @else
-                        FREE.
-                    @endif
-                </div>
+                <div class="flex justify-center text-black text-3xl font-bold">Votes: {{ $date->votes->count() }}</div>
                 <div class="flex justify-center">
                     <div class="flex flex-col md:flex-row md:justify-between md:items-center">
                         <details class="collapse collapse-arrow bg-white hover:bg-gray-300 my-2 md:my-0 md:w-1/2">
                             <summary class="collapse-title text-md font-bold">CLICK TO SEE WHO VOTED</summary>
                             <div class="collapse-content px-4 md:px-6">
-                                @if ($date->votes->isEmpty())
+                                @if($date->votes->isEmpty())
                                     <div class="font-bold">NO VOTES ON THIS DATE</div>
                                 @else
                                     <div class="font-bold mb-2 md:mb-4">PEOPLE WHO VOTED:</div>
-                                    @foreach ($date->votes as $vote)
+                                    @foreach($date->votes as $vote)
                                         <div class="mb-1">{{ $vote->voted_by }}</div>
                                     @endforeach
                                 @endif
@@ -98,3 +97,42 @@
         @endforeach
     </ul>
 @endforeach
+<script>
+    function finalizeDate(event) {
+    const dateId = event.target.dataset.dateId;
+    const dateElement = document.querySelector(`.p-6[data-date-id="${dateId}"]`);
+
+    // Gets the previously selected date element, if any
+    const previousSelectedElement = document.querySelector('.p-6[data-selected="1"]');
+    if (previousSelectedElement) {
+        // Sets the selected attribute of the previous date element to 0
+        previousSelectedElement.setAttribute('data-selected', '0');
+
+        // Removes the selected badge from the previous date element
+        const selectedBadge = previousSelectedElement.querySelector('.selected-badge');
+        if (selectedBadge) {
+            selectedBadge.remove();
+        }
+    }
+
+    // Sets the selected attribute of the current date element to 1
+    dateElement.setAttribute('data-selected', '1');
+
+    // Checks if the selected badge already exists
+    const selectedBadgeElement = dateElement.querySelector('.selected-badge');
+    if (!selectedBadgeElement) {
+        // Creates and appends the "Selected" badge
+        const badgeElement = document.createElement('div');
+        badgeElement.classList.add('badge', 'badge-outline', 'text-red-500', 'outline-red-500', 'mt-3', 'selected-badge');
+        badgeElement.innerText = 'Selected';
+        dateElement.appendChild(badgeElement);
+    }
+}
+document.addEventListener('DOMContentLoaded', function() {
+    const finalizeButtons = document.querySelectorAll('.assign-selected');
+    finalizeButtons.forEach(function(button) {
+        button.addEventListener('click', finalizeDate);
+    });
+});
+</script>
+

--- a/resources/views/meetings/meeting-cards.blade.php
+++ b/resources/views/meetings/meeting-cards.blade.php
@@ -100,69 +100,49 @@
 @endforeach
 <script>
     document.addEventListener('DOMContentLoaded', function() {
-    // Function to check if a date is selected and add a "Selected" badge
-    function checkAndAssignSelectedBadge() {
-        const dateElements = document.querySelectorAll('.p-6');
-        dateElements.forEach(dateElement => {
-            const isSelected = dateElement.getAttribute('data-selected') === '1';
-            const selectedBadgeElement = dateElement.querySelector('.selected-badge');
-
-            if (isSelected && !selectedBadgeElement) {
-                const badgeElement = document.createElement('div');
-                badgeElement.classList.add('badge', 'badge-outline', 'text-red-500', 'outline-red-500', 'mt-3', 'selected-badge');
-                badgeElement.innerText = 'Selected';
-                dateElement.appendChild(badgeElement);
-            }
+        const finalizeButtons = document.querySelectorAll('.assign-selected');
+        finalizeButtons.forEach(button => {
+            button.addEventListener('click', finalizeDate);
         });
-    }
-
-    // Call the function to check and assign selected badges
-    checkAndAssignSelectedBadge();
-
-    const finalizeButtons = document.querySelectorAll('.assign-selected');
-    finalizeButtons.forEach(function(button) {
-        button.addEventListener('click', finalizeDate);
     });
-});
 
-function finalizeDate(event) {
-    event.preventDefault(); // Prevent the form from submitting
+    function finalizeDate(event) {
+        event.preventDefault();
 
-    const dateId = event.target.dataset.dateId;
-    const dateElement = document.querySelector(`.p-6[data-date-id="${dateId}"]`);
+        const dateId = event.target.dataset.dateId;
+        const dateElement = document.querySelector(`.p-6[data-date-id="${dateId}"]`);
+        const isSelected = dateElement.getAttribute('data-selected') === '1';
 
-    const allDateElements = document.querySelectorAll('.p-6');
-    allDateElements.forEach((element) => {
-        const selectedBadge = element.querySelector('.selected-badge');
-        if (selectedBadge) {
-            selectedBadge.remove();
+        const allDateElements = document.querySelectorAll('.p-6');
+        allDateElements.forEach(element => {
+            const selectedBadge = element.querySelector('.selected-badge');
+            if (selectedBadge) {
+                selectedBadge.remove();
+            }
+            element.removeAttribute('data-selected');
+        });
+
+        dateElement.setAttribute('data-selected', '1');
+        if (!isSelected) {
+            const badgeElement = document.createElement('div');
+            badgeElement.classList.add('badge', 'badge-outline', 'text-red-500', 'outline-red-500', 'mt-3', 'selected-badge');
+            badgeElement.innerText = 'Selected';
+            dateElement.querySelector('.flex').prepend(badgeElement);
         }
-        element.removeAttribute('data-selected');
-    });
 
-    dateElement.setAttribute('data-selected', '1');
-    const badgeElement = document.createElement('div');
-    badgeElement.classList.add('badge', 'badge-outline', 'text-red-500', 'outline-red-500', 'mt-3', 'selected-badge');
-    badgeElement.innerText = 'Selected';
-    dateElement.querySelector('.flex').prepend(badgeElement);
+        const selectedDateIdInput = dateElement.querySelector('.selected-date-id-input');
+        if (selectedDateIdInput) {
+            selectedDateIdInput.value = dateId;
+        }
 
-    // Set the selected date ID in the hidden input field of the form
-    const selectedDateIdInput = dateElement.querySelector('.selected-date-id-input');
-    if (selectedDateIdInput) {
-        selectedDateIdInput.value = dateId;
+        const selectedInput = dateElement.querySelector('.selected-input');
+        if (selectedInput) {
+            selectedInput.value = '1';
+        }
+
+        const selectedDateForm = dateElement.querySelector('.selected-date-form');
+        if (selectedDateForm) {
+            selectedDateForm.submit();
+        }
     }
-
-    // Set the "selected" value in the hidden input field
-    const selectedInput = dateElement.querySelector('.selected-input');
-    if (selectedInput) {
-        selectedInput.value = '1'; // Set to 1 to indicate selected
-    }
-
-    // Submit the form
-    const selectedDateForm = dateElement.querySelector('.selected-date-form');
-    if (selectedDateForm) {
-        selectedDateForm.submit();
-    }
-}
-
 </script>

--- a/resources/views/meetings/meeting-cards.blade.php
+++ b/resources/views/meetings/meeting-cards.blade.php
@@ -74,7 +74,17 @@
                         </div>
                     </div>
                 </div>
-
+            
+                <div class="font-bold text-xl flex justify-center mt-4"></div>
+                <div class="flex justify-center text-black text-3xl font-bold">
+                    @if ($meeting->is1v1 === 0)
+                        Votes: {{ $date->votes->count() }}
+                    @elseif ($meeting->is1v1 === 1 && $isDateTaken)
+                        TAKEN.
+                    @else
+                        FREE.
+                    @endif
+                </div>
                 <div class="font-bold text-xl flex justify-center mt-4"></div>
                 <div class="flex justify-center text-black text-3xl font-bold">Votes: {{ $date->votes->count() }}</div>
                 <div class="flex justify-center">

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,7 +28,6 @@ Route::middleware('auth')->group(function () {
     Route::patch('/meeting/{id}/edit', [MeetingController::class, 'update'])->name('meetings.update');
     Route::put('/vote/{id}', [VoteController::class, 'update'])->name('vote.update');
     Route::delete('/vote/{id}', [VoteController::class, 'destroy'])->name('vote.destroy');
-    Route::post('/dates/{id}/select', [DateController::class, 'select'])->name('dates.select');
     Route::view('/pr', 'pr-egg');
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,7 @@ Route::middleware('auth')->group(function () {
     Route::patch('/meeting/{id}/edit', [MeetingController::class, 'update'])->name('meetings.update');
     Route::put('/vote/{id}', [VoteController::class, 'update'])->name('vote.update');
     Route::delete('/vote/{id}', [VoteController::class, 'destroy'])->name('vote.destroy');
+    Route::post('/dates/{id}/select', [DateController::class, 'select'])->name('dates.select');
     Route::view('/pr', 'pr-egg');
 });
 


### PR DESCRIPTION
Added an option in the dropdown menu to finalize a date. This saves the value to the database. Only one date may be selected per meeting. If another one was already selected, it no longer becomes selected, instead assigning it to the newly selected date. This is to prevent the meeting creator from accidentally selecting the wrong date and having to re-do the meeting.

I changed the following:

- In `app/Models/Date.php` I added the 'selected' attribute to each date. I updated the migrations table accordingly, assigning it the type of 'tinyInteger'. Didn't use booleans because MySQL apparently doesn't like them.

- In `app/Http/Controllers/DateController.php`, I edited the "update" function. Previously it was used for updating dates, but since that functionality isn't used anymore, I repurposed it for updating the date's "selected" attribute to the database instead. Previously I used a `select` function for this, but I figured using an already existing function would be more efficient.

- In `app/Http/Requests/StoreDate.php` I changed the `rules` function. Now the rules regarding the date numbers and uniqueness only apply when a new date is being created. This prevents unnecessary checks from back when you could edit dates. Now these rules apply only when adding a date. 

- In `resources/views/meetings/meeting-cards.blade.php` I changed the forms to allow the "Finalize" button to work, while retaining previous functionality. I also added JavaScript at the end, which is responsible for checking whether a date is selected and assigning a badge indicating so. This script is quite large and situational, so I figured keeping it here may be a better choice than loading it each time in `app.js`.

- Finally, removed a route I had previously added, since it was no longer necessary due to the `select` function no longer existing.