### PR TITLE
Adjust branding for beta release

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,5 +21,11 @@
                 {{ $slot }}
             </main>
         </div>
+        <footer class="footer footer-center p-4 bg-white text-black">
+            <div>
+                <p>Timely, a meeting scheduling and time managing web app
+                    Copyright (C) 2023 Kibernetiku klubas | v1.1.0-beta</p>
+            </div>
+        </footer>
     </body>
 </html>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,7 +1,7 @@
 <nav>
     <div class="navbar bg-white border-b-2 text-black flex flex-col sm:flex-row sm:justify-between w-full">
         <div class="flex-1 flex justify-center sm:justify-start">
-            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely <span class="text-sm">Beta</span></a>
+            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely <span class="text-sm mt-2">Beta</span></a>
         </div>
         <div class="flex justify-center sm:justify-end">
             <a href="/add-meeting" class="font-bold btn btn-ghost mx-4 sm:mx-6 text-xl flex items-center">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,7 +1,7 @@
 <nav>
     <div class="navbar bg-white border-b-2 text-black flex flex-col sm:flex-row sm:justify-between w-full">
         <div class="flex-1 flex justify-center sm:justify-start">
-            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely</a>
+            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely <span class="text-sm">Beta</span></a>
         </div>
         <div class="flex justify-center sm:justify-end">
             <a href="/add-meeting" class="font-bold btn btn-ghost mx-4 sm:mx-6 text-xl flex items-center">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,7 +1,7 @@
 <nav>
     <div class="navbar bg-white border-b-2 text-black flex flex-col sm:flex-row sm:justify-between w-full">
         <div class="flex-1 flex justify-center sm:justify-start">
-            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely <span class="text-sm mt-2">Beta</span></a>
+            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely <span class="text-sm mt-1.5">Beta</span></a>
         </div>
         <div class="flex justify-center sm:justify-end">
             <a href="/add-meeting" class="font-bold btn btn-ghost mx-4 sm:mx-6 text-xl flex items-center">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -58,7 +58,7 @@
 <body class="antialiased">
 <div class="relative bg-white">
     <div class="flex justify-between items-center p-6">
-        <a class="text-2xl text-black font-bold btn-ghost rounded-xl" href="/">Timely</a>
+        <a class="text-2xl text-black font-bold btn-ghost rounded-xl" href="/">Timely <span class="text-sm">Beta</span> </a>
         @if (Route::has('login'))
             <div class="text-right">
                 @auth
@@ -193,7 +193,7 @@
 <footer class="footer footer-center p-4 bg-white text-black">
     <div>
         <p>Timely, a meeting scheduling and time managing web app
-            Copyright (C) 2023 Kibernetiku klubas</p>
+            Copyright (C) 2023 Kibernetiku klubas | v1.1.0-beta</p>
     </div>
 </footer>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>


### PR DESCRIPTION
The project branding has been updated to reflect the move to a beta release phase. Specifically, the application name shown in the `navbar` and on the welcome page is now "Timely Beta", and the copyright notice in the footer now includes the version "v1.1.0-beta". This ensures that users are aware they are using a beta version of the application. Also added a footer tto app layout, so all pages now have a footer.