### PR TITLE
Add export to iCalendar functionality

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,5 +21,11 @@
                 {{ $slot }}
             </main>
         </div>
+        <footer class="footer footer-center p-4 bg-white text-black">
+            <div>
+                <p>Timely, a meeting scheduling and time managing web app
+                    Copyright (C) 2023 Kibernetiku klubas | v1.1.0-beta</p>
+            </div>
+        </footer>
     </body>
 </html>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,7 +1,7 @@
 <nav>
     <div class="navbar bg-white border-b-2 text-black flex flex-col sm:flex-row sm:justify-between w-full">
         <div class="flex-1 flex justify-center sm:justify-start">
-            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely <span class="text-sm">Beta</span></a>
+            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely <span class="text-sm mt-2">Beta</span></a>
         </div>
         <div class="flex justify-center sm:justify-end">
             <a href="/add-meeting" class="font-bold btn btn-ghost mx-4 sm:mx-6 text-xl flex items-center">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,7 +1,7 @@
 <nav>
     <div class="navbar bg-white border-b-2 text-black flex flex-col sm:flex-row sm:justify-between w-full">
         <div class="flex-1 flex justify-center sm:justify-start">
-            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely</a>
+            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely <span class="text-sm">Beta</span></a>
         </div>
         <div class="flex justify-center sm:justify-end">
             <a href="/add-meeting" class="font-bold btn btn-ghost mx-4 sm:mx-6 text-xl flex items-center">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,7 +1,7 @@
 <nav>
     <div class="navbar bg-white border-b-2 text-black flex flex-col sm:flex-row sm:justify-between w-full">
         <div class="flex-1 flex justify-center sm:justify-start">
-            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely <span class="text-sm mt-2">Beta</span></a>
+            <a class="btn btn-ghost normal-case text-xl" href="{{ route('dashboard') }}">Timely <span class="text-sm mt-1.5">Beta</span></a>
         </div>
         <div class="flex justify-center sm:justify-end">
             <a href="/add-meeting" class="font-bold btn btn-ghost mx-4 sm:mx-6 text-xl flex items-center">

--- a/resources/views/meetings/meeting-cards.blade.php
+++ b/resources/views/meetings/meeting-cards.blade.php
@@ -68,6 +68,10 @@
                     </div>
                 </div>
 
+                <a href="{{ route('export.ics', $date) }}"
+                   class="text-black flex justify-center hover:bg-gray-300 mt-2 btn btn-ghost">
+                    Export to calendar
+                </a>
                 <div class="font-bold text-xl flex justify-center mt-4"></div>
                 <div class="flex justify-center text-black text-3xl font-bold">
                     @if ($meeting->is1v1 === 0)

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -58,7 +58,7 @@
 <body class="antialiased">
 <div class="relative bg-white">
     <div class="flex justify-between items-center p-6">
-        <a class="text-2xl text-black font-bold btn-ghost rounded-xl" href="/">Timely</a>
+        <a class="text-2xl text-black font-bold btn-ghost rounded-xl" href="/">Timely <span class="text-sm">Beta</span> </a>
         @if (Route::has('login'))
             <div class="text-right">
                 @auth
@@ -193,7 +193,7 @@
 <footer class="footer footer-center p-4 bg-white text-black">
     <div>
         <p>Timely, a meeting scheduling and time managing web app
-            Copyright (C) 2023 Kibernetiku klubas</p>
+            Copyright (C) 2023 Kibernetiku klubas | v1.1.0-beta</p>
     </div>
 </footer>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ Route::view('/', 'welcome');
 
 Route::get('meetings/{id}', [MeetingController::class, 'show'])->name('meeting.show');
 Route::post('/votes', [VoteController::class, 'store'])->name('vote.store');
+Route::get('/export/{meeting_id}/ics', [DateController::class, 'exportToICalendar'])->name('export.ics');
 
 Route::middleware('auth')->group(function () {
 


### PR DESCRIPTION
A new method 'exportToICalendar' has been added to the 'DateController' to allow users to export meeting dates to their iCalendar. This method creates a new route 'export.ics' that returns the iCal file, which can be then directly imported into a user's personal calendar. An 'Export to calendar' button has been added to the UI for ease of use. Currently added this button to all dates, but in the future we will have a separate export button, that will export selected date.