### PR TITLE
Add Terms of Service and Privacy Policy agreement to register form

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -5,37 +5,52 @@
 
         <!-- Name -->
         <div>
-            <x-input-label for="name" :value="__('USERNAME')" />
-            <x-text-input id="name" class="block mt-1 w-full lowercase" type="text" name="name" :value="old('name')" required autofocus autocomplete="username" />
-            <x-input-error :messages="$errors->get('name')" class="mt-2" />
+            <x-input-label for="name" :value="__('USERNAME')"/>
+            <x-text-input id="name" class="block mt-1 w-full lowercase" type="text" name="name" :value="old('name')"
+                          required autofocus autocomplete="username"/>
+            <x-input-error :messages="$errors->get('name')" class="mt-2"/>
         </div>
 
 
         <!-- Password -->
         <div class="mt-4">
-            <x-input-label for="password" :value="__('PASSWORD')" />
+            <x-input-label for="password" :value="__('PASSWORD')"/>
 
             <x-text-input id="password" class="block mt-1 w-full"
-                            type="password"
-                            name="password"
-                            required autocomplete="new-password" />
+                          type="password"
+                          name="password"
+                          required autocomplete="new-password"/>
 
-            <x-input-error :messages="$errors->get('password')" class="mt-2" />
+            <x-input-error :messages="$errors->get('password')" class="mt-2"/>
         </div>
 
         <!-- Confirm Password -->
         <div class="mt-4">
-            <x-input-label for="password_confirmation" :value="__('CONFIRM PASSWORD')" />
+            <x-input-label for="password_confirmation" :value="__('CONFIRM PASSWORD')"/>
 
             <x-text-input id="password_confirmation" class="block mt-1 w-full"
-                            type="password"
-                            name="password_confirmation" required autocomplete="new-password" />
+                          type="password"
+                          name="password_confirmation" required autocomplete="new-password"/>
 
-            <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
+            <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2"/>
         </div>
 
+
+        <div class="mt-4">
+            <div class="flex items-center">
+                <input type="checkbox" class="checkbox" name="terms" id="terms" required>
+
+                <div class="ml-2">
+                    I agree to the
+                    <a target="_blank" href="/" class="underline text-sm text-gray-600 hover:text-gray-900">Terms of Service</a>
+                    and
+                    <a target="_blank" href="/" class="underline text-sm text-gray-600 hover:text-gray-900">Privacy Policy</a>
+                </div>
+            </div>
+        </div>
         <div class="flex items-center justify-end mt-4">
-            <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('login') }}">
+            <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+               href="{{ route('login') }}">
                 {{ __('Already registered?') }}
             </a>
 


### PR DESCRIPTION
An update has been made to the registration form. Users are now asked to confirm their agreement to the Terms of Service and Privacy Policy before registration is allowed. A checkbox and links to the relevant policies have been added. It doesn't link anywhere currently, as both tos and pp are not yet in the site.