### PR TITLE
Feature/add-lithuanian-translation

### DIFF
--- a/lang/en/add.php
+++ b/lang/en/add.php
@@ -1,0 +1,43 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Add page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'create' => 'CREATE A',
+    'new' => 'NEW MEETING.',
+    'tab_name' => 'Create a meeting',
+    'which' => 'Which meeting type is right for me?',
+    'group' => 'Group meeting.',
+    'group_expl' => 'Choose group meeting if you need to find 
+    the meeting time that suits the most people',
+    'or' => 'OR',
+    '1v1' => '1 on 1 meeting.',
+    '1v1_expl' => 'Choose multiple times and allow participants to book the slot 
+    that best suits their schedule.',
+    'ok' => 'Got it!',
+    'select' => 'SELECT MEETING TYPE',
+    'title' => 'TITLE',
+    'desc' => 'DESCRIPTION',
+    'location' => 'LOCATION',
+    'timezone' => 'TIMEZONE',
+    'selecttimezone' => 'Please select a timezone',
+    'mustselect' => 'Timezone must be selected.',
+    'duration' => 'MEETING DURATION (MIN):',
+    'title_placeholder' => 'Meeting Title',
+    'location_placeholder' => 'Meeting Location (e.g., Conference Room A, Online)',
+    'duration_placeholder' => 'Estimated Meeting Duration',
+    'delete_after' => 'DELETE AFTER (DAYS) FROM CREATION:',
+    'deletion_placeholder' => 'Choose time until deletion',
+    'cancel' => 'Cancel',
+    'confirm' => 'Create meeting',
+];

--- a/lang/en/auth.php
+++ b/lang/en/auth.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed' => 'These credentials do not match our records.',
+    'password' => 'The provided password is incorrect.',
+    'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
+
+];

--- a/lang/en/confirm-delete.php
+++ b/lang/en/confirm-delete.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Confirm-delete page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'delete' => 'DELETE',
+    'meeting' => 'MEETING.',
+    'confirm' => 'Are you sure you want to delete this meeting?',
+    'cancel' => 'Cancel',
+    'confirm-delete' => 'Confirm deletion',
+];

--- a/lang/en/confirm-password.php
+++ b/lang/en/confirm-password.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Forgot-password Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'warning' => 'This is a secure area of the application. 
+    Please confirm your password before continuing.',
+    'passwd' => 'Password',
+    'confirm' => 'Confirm',
+    
+];

--- a/lang/en/dashboard.php
+++ b/lang/en/dashboard.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Dashboard Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'your' => 'your',
+    'meetings' => 'meetings',
+    'nomeetingsyet' => 'No meetings yet',
+    'createfirstmeet' => 'Create your first meeting by pressing "Create a meeting" button',
+    
+];

--- a/lang/en/delete-user.php
+++ b/lang/en/delete-user.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Delete-User Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'deleteacc' => 'Delete Account',
+    'deletewarning' => 'Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.',
+    'deleteareyousure' => 'Are you sure you want to delete your account?',
+    'deleteconfirmwarn' => 'Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.',
+    'password' => 'Password',
+    'cancel' => 'Cancel',
+];

--- a/lang/en/edit-meeting-buttons.php
+++ b/lang/en/edit-meeting-buttons.php
@@ -15,4 +15,5 @@ return [
 
     'edit' => 'Edit meeting and votes',
     'delete' => 'Delete meeting',
+    'finalize' => 'Finalize a time',
 ];

--- a/lang/en/edit-meeting-buttons.php
+++ b/lang/en/edit-meeting-buttons.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Edit-times page Language Lines
+    | Edit-meeting-buttons page Language Lines
     |--------------------------------------------------------------------------
     |
     | The following language lines are used by the paginator library to build
@@ -13,7 +13,6 @@ return [
     |
     */
 
-    'times' => 'ADD TIMES',
-    'select' => 'SELECT A NEW TIME',
-    'addtime' => 'Add time',
+    'edit' => 'Edit meeting and votes',
+    'delete' => 'Delete meeting',
 ];

--- a/lang/en/edit-meeting.php
+++ b/lang/en/edit-meeting.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Edit meeting page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'edita' => 'EDIT A',
+    'meeting' => 'MEETING.',
+    'title' => 'TITLE',
+    'desc' => 'DESCRIPTION',
+    'location' => 'LOCATION',
+    'timezone' => 'TIMEZONE',
+    'selecttimezone' => 'Please select a timezone',
+    'mustselect' => 'Timezone must be selected.',
+    'duration' => 'MEETING DURATION (MIN):',
+    'title_placeholder' => 'Meeting Title',
+    'location_placeholder' => 'Meeting Location (e.g., Conference Room A, Online)',
+    'duration_placeholder' => 'Estimated Meeting Duration',
+    'delete_after' => 'DELETE AFTER (DAYS) FROM CREATION:',
+    'deletion_placeholder' => 'Choose time until deletion',
+    'cancel' => 'Cancel',
+    'update' => 'update meeting',
+];

--- a/lang/en/edit-times.php
+++ b/lang/en/edit-times.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Edit-votes page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'times' => 'ADD TIMES',
+    'select' => 'SELECT A NEW TIME',
+    'addtime' => 'Add time',
+];

--- a/lang/en/edit-votes.php
+++ b/lang/en/edit-votes.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Edit-votes page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'clickhere' => 'Click here to edit votes',
+    'select' => 'Select a time to edit votes:',
+    'date' => 'Date and Time:',
+    'editname' => 'EDIT VOTE NAME',
+    'save' => 'Save',
+    'delete' => 'Delete vote',
+    'novotes' => 'No votes on this date',
+    'nodates' => 'No dates exist for this meeting',
+    
+];

--- a/lang/en/edit.php
+++ b/lang/en/edit.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Edit page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'profile' => 'Profile.',
+    'profile_tab' => 'Profile',
+
+];

--- a/lang/en/forgot-password.php
+++ b/lang/en/forgot-password.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Forgot-password Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'forgot' => 'Forgot your password? No problem. Just let us know your email address 
+    and we will email you a password reset link that will allow you to choose a new one.',
+    'email' => 'Email',
+    'send' => 'Email Password Reset Link',
+    
+];

--- a/lang/en/guest.php
+++ b/lang/en/guest.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Add page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'welcome' => 'WELCOME TO',
+];

--- a/lang/en/login.php
+++ b/lang/en/login.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Register Language Lines
+    | Login Language Lines
     |--------------------------------------------------------------------------
     |
     | The following language lines are used by the paginator library to build
@@ -13,10 +13,11 @@ return [
     |
     */
 
+    'tab' => 'Login',
     'name' => 'USERNAME',
     'passwd' => 'PASSWORD',
-    'confirm' => 'CONFIRM PASSWORD',
-    'registered' => 'Already registered?',
-    'register' => 'Register',
+    'remember' => 'Remember me',
+    'noacc' => 'Don\'t have an account yet?',
+    'login' => 'Log in',
     
 ];

--- a/lang/en/meeting-cards.php
+++ b/lang/en/meeting-cards.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Meeting-cards Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'mostvoted' => 'Most voted',
+    'delete' => 'Delete',
+    'confirm' => 'Confirm Deletion.',
+    'confirm_message' => 'Are you sure you want to delete this date?',
+    'cancel' => 'Cancel',
+    'confirmdelete' => 'Confirm Delete',
+    'export' => 'Export to calendar',
+    'votes' => 'Votes:',
+    'taken' => 'TAKEN.',
+    'free' => 'FREE.',
+    'seewho' => 'CLICK TO SEE WHO VOTED',
+    'novotes' => 'NO VOTES ON THIS DATE',
+    'whovoted' => 'PEOPLE WHO VOTED:',
+];

--- a/lang/en/meeting-info.php
+++ b/lang/en/meeting-info.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Meeting-info Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'createdby' => 'Meeting created by',
+    'minutes' => 'minutes',
+    'link' => 'Link to meeting:',
+    'data-tip' => 'Press the icon on the right to copy',
+    
+    
+];

--- a/lang/en/meeting.php
+++ b/lang/en/meeting.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Meeting Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'meeting' => 'MEETING.',
+    'dates' => 'DATES AND TIMES FOR THE MEETING:',
+    '1v1' => 'Note: This meeting is 1 on 1, so only one vote per date is allowed.',
+    'timesarein' => 'All times are in',
+    'timezone' => 'timezone',
+    'nodates' => 'NO DATES YET',
+    'adddates' => 'Add dates by using the date selector above',
+    
+];

--- a/lang/en/navigation.php
+++ b/lang/en/navigation.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Add page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'create' => 'CREATE A MEETING',
+    'profile' => 'Profile',
+    'logout' => 'Log Out',
+];

--- a/lang/en/pagination.php
+++ b/lang/en/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; Previous',
+    'next' => 'Next &raquo;',
+
+];

--- a/lang/en/passwords.php
+++ b/lang/en/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'reset' => 'Your password has been reset.',
+    'sent' => 'We have emailed your password reset link.',
+    'throttled' => 'Please wait before retrying.',
+    'token' => 'This password reset token is invalid.',
+    'user' => "We can't find a user with that email address.",
+
+];

--- a/lang/en/register.php
+++ b/lang/en/register.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reset-password Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'name' => 'USERNAME',
+    'passwd' => 'PASSWORD',
+    'confirm' => 'CONFIRM PASSWORD',
+    'registered' => 'Already registered?',
+    'register' => 'Register',
+    
+];

--- a/lang/en/register.php
+++ b/lang/en/register.php
@@ -13,10 +13,15 @@ return [
     |
     */
 
+    'tab' => 'Register',
     'name' => 'USERNAME',
     'passwd' => 'PASSWORD',
     'confirm' => 'CONFIRM PASSWORD',
     'registered' => 'Already registered?',
     'register' => 'Register',
+    'agree' => 'I agree to the',
+    'tos' => 'Terms of Service',
+    'and' => 'and',
+    'policy' => 'Privacy Policy',
     
 ];

--- a/lang/en/reset-password.php
+++ b/lang/en/reset-password.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reset-password Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'email' => 'Email',
+    'passwd' => 'Password',
+    'confirm' => 'Confirm Password',
+    'reset' => 'Reset Password',
+    
+];

--- a/lang/en/update-password.php
+++ b/lang/en/update-password.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Update-Profile Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'updatepas' => 'Update Password',
+    'ensure' => 'Ensure your account is using a long, random password to stay secure.',
+    'curpassword' => 'CURRENT PASSWORD',
+    'newpassword' => 'NEW PASSWORD',
+    'confirmpassword' => 'CONFIRM PASSWORD',
+    
+];

--- a/lang/en/update-password.php
+++ b/lang/en/update-password.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Update-Profile Page Language lines
+    | Update-Password Page Language lines
     |--------------------------------------------------------------------------
     |
     | The following language lines are used by the paginator library to build

--- a/lang/en/update-profile-information.php
+++ b/lang/en/update-profile-information.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Update-Profile Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'profileinfo' => 'Profile Information',
+    'updateinfo' => "Update your account's profile information and email address.",
+    'profilename' => 'Name',
+    'profilemail' => 'Email',
+    'adressunverified' => 'Your email address is unverified.',
+    'resendmail' => 'Click here to re-send the verification email.',
+    'sendreset' => 'A new verification link has been sent to your email address.',
+    'save' => 'Save',
+    'saved' => 'Saved',
+];

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -1,0 +1,185 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | as the size rules. Feel free to tweak each of these messages here.
+    |
+    */
+
+    'accepted' => 'The :attribute field must be accepted.',
+    'accepted_if' => 'The :attribute field must be accepted when :other is :value.',
+    'active_url' => 'The :attribute field must be a valid URL.',
+    'after' => 'The :attribute field must be a date after :date.',
+    'after_or_equal' => 'The :attribute field must be a date after or equal to :date.',
+    'alpha' => 'The :attribute field must only contain letters.',
+    'alpha_dash' => 'The :attribute field must only contain letters, numbers, dashes, and underscores.',
+    'alpha_num' => 'The :attribute field must only contain letters and numbers.',
+    'array' => 'The :attribute field must be an array.',
+    'ascii' => 'The :attribute field must only contain single-byte alphanumeric characters and symbols.',
+    'before' => 'The :attribute field must be a date before :date.',
+    'before_or_equal' => 'The :attribute field must be a date before or equal to :date.',
+    'between' => [
+        'array' => 'The :attribute field must have between :min and :max items.',
+        'file' => 'The :attribute field must be between :min and :max kilobytes.',
+        'numeric' => 'The :attribute field must be between :min and :max.',
+        'string' => 'The :attribute field must be between :min and :max characters.',
+    ],
+    'boolean' => 'The :attribute field must be true or false.',
+    'can' => 'The :attribute field contains an unauthorized value.',
+    'confirmed' => 'The :attribute field confirmation does not match.',
+    'current_password' => 'The password is incorrect.',
+    'date' => 'The :attribute field must be a valid date.',
+    'date_equals' => 'The :attribute field must be a date equal to :date.',
+    'date_format' => 'The :attribute field must match the format :format.',
+    'decimal' => 'The :attribute field must have :decimal decimal places.',
+    'declined' => 'The :attribute field must be declined.',
+    'declined_if' => 'The :attribute field must be declined when :other is :value.',
+    'different' => 'The :attribute field and :other must be different.',
+    'digits' => 'The :attribute field must be :digits digits.',
+    'digits_between' => 'The :attribute field must be between :min and :max digits.',
+    'dimensions' => 'The :attribute field has invalid image dimensions.',
+    'distinct' => 'The :attribute field has a duplicate value.',
+    'doesnt_end_with' => 'The :attribute field must not end with one of the following: :values.',
+    'doesnt_start_with' => 'The :attribute field must not start with one of the following: :values.',
+    'email' => 'The :attribute field must be a valid email address.',
+    'ends_with' => 'The :attribute field must end with one of the following: :values.',
+    'enum' => 'The selected :attribute is invalid.',
+    'exists' => 'The selected :attribute is invalid.',
+    'file' => 'The :attribute field must be a file.',
+    'filled' => 'The :attribute field must have a value.',
+    'gt' => [
+        'array' => 'The :attribute field must have more than :value items.',
+        'file' => 'The :attribute field must be greater than :value kilobytes.',
+        'numeric' => 'The :attribute field must be greater than :value.',
+        'string' => 'The :attribute field must be greater than :value characters.',
+    ],
+    'gte' => [
+        'array' => 'The :attribute field must have :value items or more.',
+        'file' => 'The :attribute field must be greater than or equal to :value kilobytes.',
+        'numeric' => 'The :attribute field must be greater than or equal to :value.',
+        'string' => 'The :attribute field must be greater than or equal to :value characters.',
+    ],
+    'image' => 'The :attribute field must be an image.',
+    'in' => 'The selected :attribute is invalid.',
+    'in_array' => 'The :attribute field must exist in :other.',
+    'integer' => 'The :attribute field must be an integer.',
+    'ip' => 'The :attribute field must be a valid IP address.',
+    'ipv4' => 'The :attribute field must be a valid IPv4 address.',
+    'ipv6' => 'The :attribute field must be a valid IPv6 address.',
+    'json' => 'The :attribute field must be a valid JSON string.',
+    'lowercase' => 'The :attribute field must be lowercase.',
+    'lt' => [
+        'array' => 'The :attribute field must have less than :value items.',
+        'file' => 'The :attribute field must be less than :value kilobytes.',
+        'numeric' => 'The :attribute field must be less than :value.',
+        'string' => 'The :attribute field must be less than :value characters.',
+    ],
+    'lte' => [
+        'array' => 'The :attribute field must not have more than :value items.',
+        'file' => 'The :attribute field must be less than or equal to :value kilobytes.',
+        'numeric' => 'The :attribute field must be less than or equal to :value.',
+        'string' => 'The :attribute field must be less than or equal to :value characters.',
+    ],
+    'mac_address' => 'The :attribute field must be a valid MAC address.',
+    'max' => [
+        'array' => 'The :attribute field must not have more than :max items.',
+        'file' => 'The :attribute field must not be greater than :max kilobytes.',
+        'numeric' => 'The :attribute field must not be greater than :max.',
+        'string' => 'The :attribute field must not be greater than :max characters.',
+    ],
+    'max_digits' => 'The :attribute field must not have more than :max digits.',
+    'mimes' => 'The :attribute field must be a file of type: :values.',
+    'mimetypes' => 'The :attribute field must be a file of type: :values.',
+    'min' => [
+        'array' => 'The :attribute field must have at least :min items.',
+        'file' => 'The :attribute field must be at least :min kilobytes.',
+        'numeric' => 'The :attribute field must be at least :min.',
+        'string' => 'The :attribute field must be at least :min characters.',
+    ],
+    'min_digits' => 'The :attribute field must have at least :min digits.',
+    'missing' => 'The :attribute field must be missing.',
+    'missing_if' => 'The :attribute field must be missing when :other is :value.',
+    'missing_unless' => 'The :attribute field must be missing unless :other is :value.',
+    'missing_with' => 'The :attribute field must be missing when :values is present.',
+    'missing_with_all' => 'The :attribute field must be missing when :values are present.',
+    'multiple_of' => 'The :attribute field must be a multiple of :value.',
+    'not_in' => 'The selected :attribute is invalid.',
+    'not_regex' => 'The :attribute field format is invalid.',
+    'numeric' => 'The :attribute field must be a number.',
+    'password' => [
+        'letters' => 'The :attribute field must contain at least one letter.',
+        'mixed' => 'The :attribute field must contain at least one uppercase and one lowercase letter.',
+        'numbers' => 'The :attribute field must contain at least one number.',
+        'symbols' => 'The :attribute field must contain at least one symbol.',
+        'uncompromised' => 'The given :attribute has appeared in a data leak. Please choose a different :attribute.',
+    ],
+    'present' => 'The :attribute field must be present.',
+    'prohibited' => 'The :attribute field is prohibited.',
+    'prohibited_if' => 'The :attribute field is prohibited when :other is :value.',
+    'prohibited_unless' => 'The :attribute field is prohibited unless :other is in :values.',
+    'prohibits' => 'The :attribute field prohibits :other from being present.',
+    'regex' => 'The :attribute field format is invalid.',
+    'required' => 'The :attribute field is required.',
+    'required_array_keys' => 'The :attribute field must contain entries for: :values.',
+    'required_if' => 'The :attribute field is required when :other is :value.',
+    'required_if_accepted' => 'The :attribute field is required when :other is accepted.',
+    'required_unless' => 'The :attribute field is required unless :other is in :values.',
+    'required_with' => 'The :attribute field is required when :values is present.',
+    'required_with_all' => 'The :attribute field is required when :values are present.',
+    'required_without' => 'The :attribute field is required when :values is not present.',
+    'required_without_all' => 'The :attribute field is required when none of :values are present.',
+    'same' => 'The :attribute field must match :other.',
+    'size' => [
+        'array' => 'The :attribute field must contain :size items.',
+        'file' => 'The :attribute field must be :size kilobytes.',
+        'numeric' => 'The :attribute field must be :size.',
+        'string' => 'The :attribute field must be :size characters.',
+    ],
+    'starts_with' => 'The :attribute field must start with one of the following: :values.',
+    'string' => 'The :attribute field must be a string.',
+    'timezone' => 'The :attribute field must be a valid timezone.',
+    'unique' => 'The :attribute has already been taken.',
+    'uploaded' => 'The :attribute failed to upload.',
+    'uppercase' => 'The :attribute field must be uppercase.',
+    'url' => 'The :attribute field must be a valid URL.',
+    'ulid' => 'The :attribute field must be a valid ULID.',
+    'uuid' => 'The :attribute field must be a valid UUID.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap our attribute placeholder
+    | with something more reader friendly such as "E-Mail Address" instead
+    | of "email". This simply helps us make our message more expressive.
+    |
+    */
+
+    'attributes' => [],
+
+];

--- a/lang/en/verify-email.php
+++ b/lang/en/verify-email.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Add page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'signup' => "Thanks for signing up! Before getting started, could you verify your 
+    email address by clicking on the link we just emailed to you? 
+    If you didn\'t receive the email, we will gladly send you another.",
+    'verlink' => 'A new verification link has been sent to the 
+    email address you provided during registration.',
+    'resend' => 'Resend Verification Email',
+    'logout' => 'Log Out',
+];

--- a/lang/en/vote.php
+++ b/lang/en/vote.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Vote Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'addvotes' => 'ADD YOUR VOTES',
+    'havevoted' => 'You have already voted',
+    'voteonall' => 'VOTE ON ALL THE',
+    'timesthat' => 'TIMES THAT SUIT YOU.',
+    'header' => 'Check every time you want to vote on and enter your name to
+    save your votes.',
+    'desctop' => 'Note: Name will be visible to everyone viewing this meeting.',
+    'descbot' => 'It is also recommended to use your real name so that meeting
+    creator knows who voted.',
+    'unavailable' => 'NO DATES AVAILABLE FOR VOTING',
+    'yourname' => 'YOUR NAME',
+    'voteon' => 'VOTE ON:',
+    'savevotes' => 'Save votes',
+];

--- a/lang/en/welcome.php
+++ b/lang/en/welcome.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Welcome Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'welcome_tab' => 'Welcome! • Timely',
+    'register' => 'Register',
+    'welcometo' => 'Welcome to',
+    'schedulingyour' => 'Scheduling your',
+    'meetings' => 'meetings',
+    'madeeasy' => 'made easy.',
+    'timelydesc' => 'Having trouble finding the meeting time that suits everyone? Look no further than your free,
+    open-source and privacy respecting solution - Timely',
+    'createfirst' => 'Create your first meeting',
+    'meetingheader' => 'Simple Meeting Page: Info, Times, and Easy Voting.',
+    'meetingdesc' => 'Simplify your meetings with our user-friendly Meeting Page! Find essential
+    details, including purpose, location, and duration. Send the meeting link to all your partners. Discover
+    available time slots and vote on your preferred time, bidding farewell to scheduling headaches!',
+    'calendarheader' => 'Effortless Date and Time Selection with Simple Calendar.',
+    'calendardesc' => "Our simple calendar feature is designed to take the hassle out of date and time
+    selection, making scheduling a breeze. We believe that managing your time should be easy and
+    stress-free, and that's why our user-friendly interface provides a seamless experience for all your
+    scheduling needs.",
+    'waste' => 'Waste',
+    'nomoretime' => 'No more time.',
+    'waste_upper' => "Just like our minimalist dashboard doesn't waste your time.",
+    'waste_lower' => "Make your step to effortless meeting scheduling.",
+    'getstarted' => 'Get started.',
+];

--- a/lang/lt/add.php
+++ b/lang/lt/add.php
@@ -1,0 +1,43 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Add page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'create' => 'CREATE A',
+    'new' => 'NEW MEETING.',
+    'tab_name' => 'Create a meeting',
+    'which' => 'Which meeting type is right for me?',
+    'group' => 'Group meeting.',
+    'group_expl' => 'Choose group meeting if you need to find 
+    the meeting time that suits the most people',
+    'or' => 'OR',
+    '1v1' => '1 on 1 meeting.',
+    '1v1_expl' => 'Choose multiple times and allow participants to book the slot 
+    that best suits their schedule.',
+    'ok' => 'Got it!',
+    'select' => 'SELECT MEETING TYPE',
+    'title' => 'TITLE',
+    'desc' => 'DESCRIPTION',
+    'location' => 'LOCATION',
+    'timezone' => 'TIMEZONE',
+    'selecttimezone' => 'Please select a timezone',
+    'mustselect' => 'Timezone must be selected.',
+    'duration' => 'MEETING DURATION (MIN):',
+    'title_placeholder' => 'Meeting Title',
+    'location_placeholder' => 'Meeting Location (e.g., Conference Room A, Online)',
+    'duration_placeholder' => 'Estimated Meeting Duration',
+    'delete_after' => 'DELETE AFTER (DAYS) FROM CREATION:',
+    'deletion_placeholder' => 'Choose time until deletion',
+    'cancel' => 'Cancel',
+    'confirm' => 'Create meeting',
+];

--- a/lang/lt/auth.php
+++ b/lang/lt/auth.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed' => 'Jūsų įvesti duomenys neegzistuoja sistemoje.',
+    'password' => 'Slaptažodis neteisingas.',
+    'throttle' => 'Pernelyg daug prisijungimo bandymų. Prašome pabandyti vėl už :seconds sekundžių.',
+
+];

--- a/lang/lt/confirm-delete.php
+++ b/lang/lt/confirm-delete.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Confirm-delete page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'delete' => 'DELETE',
+    'meeting' => 'MEETING.',
+    'confirm' => 'Are you sure you want to delete this meeting?',
+    'cancel' => 'Cancel',
+    'confirm-delete' => 'Confirm deletion',
+];

--- a/lang/lt/confirm-password.php
+++ b/lang/lt/confirm-password.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Forgot-password Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'warning' => 'This is a secure area of the application. 
+    Please confirm your password before continuing.',
+    'passwd' => 'Password',
+    'confirm' => 'Confirm',
+    
+];

--- a/lang/lt/dashboard.php
+++ b/lang/lt/dashboard.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Dashboard Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'your' => 'your',
+    'meetings' => 'meetings',
+    'nomeetingsyet' => 'No meetings yet',
+    'createfirstmeet' => 'Create your first meeting by pressing "Create a meeting" button',
+    
+];

--- a/lang/lt/delete-user.php
+++ b/lang/lt/delete-user.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Delete-User Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'deleteacc' => 'Delete Account',
+    'deletewarning' => 'Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.',
+    'deleteareyousure' => 'Are you sure you want to delete your account?',
+    'deleteconfirmwarn' => 'Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.',
+    'password' => 'Password',
+    'cancel' => 'Cancel',
+];

--- a/lang/lt/edit-meeting-buttons.php
+++ b/lang/lt/edit-meeting-buttons.php
@@ -15,4 +15,5 @@ return [
 
     'edit' => 'Edit meeting and votes',
     'delete' => 'Delete meeting',
+    'finalize' => 'Finalize a time',
 ];

--- a/lang/lt/edit-meeting-buttons.php
+++ b/lang/lt/edit-meeting-buttons.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Edit-times page Language Lines
+    | Edit-meeting-buttons page Language Lines
     |--------------------------------------------------------------------------
     |
     | The following language lines are used by the paginator library to build
@@ -13,7 +13,6 @@ return [
     |
     */
 
-    'times' => 'ADD TIMES',
-    'select' => 'SELECT A NEW TIME',
-    'addtime' => 'Add time',
+    'edit' => 'Edit meeting and votes',
+    'delete' => 'Delete meeting',
 ];

--- a/lang/lt/edit-meeting.php
+++ b/lang/lt/edit-meeting.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Edit meeting page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'edita' => 'EDIT A',
+    'meeting' => 'MEETING.',
+    'title' => 'TITLE',
+    'desc' => 'DESCRIPTION',
+    'location' => 'LOCATION',
+    'timezone' => 'TIMEZONE',
+    'selecttimezone' => 'Please select a timezone',
+    'mustselect' => 'Timezone must be selected.',
+    'duration' => 'MEETING DURATION (MIN):',
+    'title_placeholder' => 'Meeting Title',
+    'location_placeholder' => 'Meeting Location (e.g., Conference Room A, Online)',
+    'duration_placeholder' => 'Estimated Meeting Duration',
+    'delete_after' => 'DELETE AFTER (DAYS) FROM CREATION:',
+    'deletion_placeholder' => 'Choose time until deletion',
+    'cancel' => 'Cancel',
+    'update' => 'update meeting',
+];

--- a/lang/lt/edit-times.php
+++ b/lang/lt/edit-times.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Edit-votes page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'times' => 'ADD TIMES',
+    'select' => 'SELECT A NEW TIME',
+    'addtime' => 'Add time',
+];

--- a/lang/lt/edit-times.php
+++ b/lang/lt/edit-times.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Edit-votes page Language Lines
+    | Edit-times page Language Lines
     |--------------------------------------------------------------------------
     |
     | The following language lines are used by the paginator library to build

--- a/lang/lt/edit-votes.php
+++ b/lang/lt/edit-votes.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Edit-votes page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'clickhere' => 'Click here to edit votes',
+    'select' => 'Select a time to edit votes:',
+    'date' => 'Date and Time:',
+    'editname' => 'EDIT VOTE NAME',
+    'save' => 'Save',
+    'delete' => 'Delete vote',
+    'novotes' => 'No votes on this date',
+    'nodates' => 'No dates exist for this meeting',
+    
+];

--- a/lang/lt/edit.php
+++ b/lang/lt/edit.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Edit page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'profile' => 'Profile.',
+    'profile_tab' => 'Profile',
+
+];

--- a/lang/lt/forgot-password.php
+++ b/lang/lt/forgot-password.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Forgot-password Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'forgot' => 'Forgot your password? No problem. Just let us know your email address 
+    and we will email you a password reset link that will allow you to choose a new one.',
+    'email' => 'Email',
+    'send' => 'Email Password Reset Link',
+    
+];

--- a/lang/lt/guest.php
+++ b/lang/lt/guest.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Add page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'welcome' => 'WELCOME TO',
+];

--- a/lang/lt/login.php
+++ b/lang/lt/login.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Register Language Lines
+    | Login Language Lines
     |--------------------------------------------------------------------------
     |
     | The following language lines are used by the paginator library to build
@@ -13,10 +13,11 @@ return [
     |
     */
 
+    'tab' => 'Login',
     'name' => 'USERNAME',
     'passwd' => 'PASSWORD',
-    'confirm' => 'CONFIRM PASSWORD',
-    'registered' => 'Already registered?',
-    'register' => 'Register',
+    'remember' => 'Remember me',
+    'noacc' => 'Don\'t have an account yet?',
+    'login' => 'Log in',
     
 ];

--- a/lang/lt/meeting-cards.php
+++ b/lang/lt/meeting-cards.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Meeting-cards Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'mostvoted' => 'Most voted',
+    'delete' => 'Delete',
+    'confirm' => 'Confirm Deletion.',
+    'confirm_message' => 'Are you sure you want to delete this date?',
+    'cancel' => 'Cancel',
+    'confirmdelete' => 'Confirm Delete',
+    'export' => 'Export to calendar',
+    'votes' => 'Votes:',
+    'taken' => 'TAKEN.',
+    'free' => 'FREE.',
+    'seewho' => 'CLICK TO SEE WHO VOTED',
+    'novotes' => 'NO VOTES ON THIS DATE',
+    'whovoted' => 'PEOPLE WHO VOTED:',
+    
+    
+    
+];

--- a/lang/lt/meeting-info.php
+++ b/lang/lt/meeting-info.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Meeting-info Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'createdby' => 'Meeting created by',
+    'minutes' => 'minutes',
+    'link' => 'Link to meeting:',
+    'data-tip' => 'Press the icon on the right to copy',
+    
+    
+];

--- a/lang/lt/meeting.php
+++ b/lang/lt/meeting.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Meeting Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'meeting' => 'MEETING.',
+    'dates' => 'DATES AND TIMES FOR THE MEETING:',
+    '1v1' => 'Note: This meeting is 1 on 1, so only one vote per date is allowed.',
+    'timesarein' => 'All times are in',
+    'timezone' => 'timezone',
+    'nodates' => 'NO DATES YET',
+    'adddates' => 'Add dates by using the date selector above',
+    
+];

--- a/lang/lt/navigation.php
+++ b/lang/lt/navigation.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Add page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'create' => 'CREATE A MEETING',
+    'profile' => 'Profile',
+    'logout' => 'Log Out',
+];

--- a/lang/lt/pagination.php
+++ b/lang/lt/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; Praeitas',
+    'next' => 'Kitas &raquo;',
+
+];

--- a/lang/lt/passwords.php
+++ b/lang/lt/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'reset' => 'Jūsų slaptažodis buvo atstatytas.',
+    'sent' => 'Mes jums el. paštu atsiuntėme slaptažodžio atstatymo nuorodą.',
+    'throttled' => 'Prašome palaukti prieš bandant iš naujo.',
+    'token' => 'Šis slaptažodžio atkūrimo žetonas nebetinka.',
+    'user' => "Negalime rasti vartotojo su šiuo adresu.",
+
+];

--- a/lang/lt/register.php
+++ b/lang/lt/register.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reset-password Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'name' => 'USERNAME',
+    'passwd' => 'PASSWORD',
+    'confirm' => 'CONFIRM PASSWORD',
+    'registered' => 'Already registered?',
+    'register' => 'Register',
+    
+];

--- a/lang/lt/register.php
+++ b/lang/lt/register.php
@@ -13,10 +13,14 @@ return [
     |
     */
 
+    'tab' => 'Register',
     'name' => 'USERNAME',
     'passwd' => 'PASSWORD',
     'confirm' => 'CONFIRM PASSWORD',
     'registered' => 'Already registered?',
     'register' => 'Register',
-    
+    'agree' => 'I agree to the',
+    'tos' => 'Terms of Service',
+    'and' => 'and',
+    'policy' => 'Privacy Policy',
 ];

--- a/lang/lt/register.php
+++ b/lang/lt/register.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Reset-password Language Lines
+    | Register Language Lines
     |--------------------------------------------------------------------------
     |
     | The following language lines are used by the paginator library to build

--- a/lang/lt/reset-password.php
+++ b/lang/lt/reset-password.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reset-password Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'email' => 'Email',
+    'passwd' => 'Password',
+    'confirm' => 'Confirm Password',
+    'reset' => 'Reset Password',
+    
+];

--- a/lang/lt/update-password.php
+++ b/lang/lt/update-password.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Update-Profile Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'updatepas' => 'Update Password',
+    'ensure' => 'Ensure your account is using a long, random password to stay secure.',
+    'curpassword' => 'CURRENT PASSWORD',
+    'newpassword' => 'NEW PASSWORD',
+    'confirmpassword' => 'CONFIRM PASSWORD',
+    
+];

--- a/lang/lt/update-password.php
+++ b/lang/lt/update-password.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Update-Profile Page Language lines
+    | Update-Password Page Language lines
     |--------------------------------------------------------------------------
     |
     | The following language lines are used by the paginator library to build

--- a/lang/lt/update-profile-information.php
+++ b/lang/lt/update-profile-information.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Update-Profile Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'profileinfo' => 'Profile Information',
+    'updateinfo' => "Update your account's profile information and email address.",
+    'profilename' => 'Name',
+    'profilemail' => 'Email',
+    'adressunverified' => 'Your email address is unverified.',
+    'resendmail' => 'Click here to re-send the verification email.',
+    'sendreset' => 'A new verification link has been sent to your email address.',
+    'save' => 'Save',
+    'saved' => 'Saved',
+];

--- a/lang/lt/validation.php
+++ b/lang/lt/validation.php
@@ -181,7 +181,8 @@ return [
     */
 
     'attributes' => [
-        'password' => 'Slaptažodis',
+        'password' => 'Slaptažodio',
+        'current_password' => 'Dabartinio slaptažodžio'
     ],
 
 ];

--- a/lang/lt/validation.php
+++ b/lang/lt/validation.php
@@ -1,0 +1,187 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | as the size rules. Feel free to tweak each of these messages here.
+    |
+    */
+
+    'accepted' => ':attribute laukelis privalo būti priimtas.',
+    'accepted_if' => ':attribute laukelis privalo būti priimtas, kai :other yra :value.',
+    'active_url' => ':attribute laukelis privalo būti tinkamas URL.',
+    'after' => ':attribute privalo būti data po :date.',
+    'after_or_equal' => ':attribute laukelis privalo būti data po arba lygi :date.',
+    'alpha' => ':attribute laukelį privalo sudaryti tik raidės.',
+    'alpha_dash' => ':attribute laukelyje gali būti tik raidės, skaičiai, brūkšneliai ir pabraukimai.',
+    'alpha_num' => ':attribute laukelyje gali būti tik raidės ir skaičiai.',
+    'array' => ':attribute laukelis gali būti masyvas.',
+    'ascii' => ':attribute laukelyje gali būti tik vieno baito raidiniai skaitmeniniai simboliai.',
+    'before' => ':attribute laukelis privalo būti data prieš :date.',
+    'before_or_equal' => ':attribute privalo būti data prieš arba lygi :date.',
+    'between' => [
+        'array' => ':attribute laukelis privalo turėti tarp :min ir :max elementų.',
+        'file' => ':attribute laukelis privalo būti tarp :min ir :max kilobaitų.',
+        'numeric' => ':attribute laukelis privalo būti tarp :min ir :max.',
+        'string' => ':attribute laukelis privalo būti tarp :min ir :max simbolių.',
+    ],
+    'boolean' => ':attribute laukelis privalo būti teisingas arba klaidingas.',
+    'can' => ':attribute laukelyje yra netinkama reikšmė.',
+    'confirmed' => ':attribute laukelio patvirtinimas neatitinka.',
+    'current_password' => 'Slaptažodis yra neteisingas.',
+    'date' => ':attribute laukelis privalo būti tinkama data.',
+    'date_equals' => ':attribute laukelis privalo būti data lygi :date.',
+    'date_format' => ':attribute laukelis privalo atitikti :format formatą.',
+    'decimal' => ':attribute laukelis privalo turėti :decimal skaičių po kablelio.',
+    'declined' => ':attribute laukelis privalo būti atmestas.',
+    'declined_if' => ':attribute laukelis privalo būti atmestas kai :other yra :value.',
+    'different' => ':attribute laukelis ir :other privalo būti skirtingi.',
+    'digits' => ':attribute laukelis privalo būti sudarytas iš :digits skaitmenų.',
+    'digits_between' => ':attribute laukelis privalo būti tarp :min ir :max skaitmenų.',
+    'dimensions' => ':attribute laukelis turi netinkamus vaizdo matmenis.',
+    'distinct' => ':attribute laukelis turi pasikartojančią reikšmę.',
+    'doesnt_end_with' => ':attribute laukelis negali pasibaigti šiomis reikšmėmis: :values.',
+    'doesnt_start_with' => ':attribute laukelis negali prasidėti šiomis reikšmėmis: :values.',
+    'email' => ':attribute laukelis privalo būti tinkamas el. paštas.',
+    'ends_with' => ':attribute laukelis privalo pasibaigti viena iš šių reikšmių: :values.',
+    'enum' => 'Pasirinktas :attribute yra netinkamas.',
+    'exists' => 'Pasirinktas :attribute yra netinkamas.',
+    'file' => ':attribute laukelis privalo būti failas.',
+    'filled' => ':attribute laukelis privalo turėti reikšmę.',
+    'gt' => [
+        'array' => ':attribute laukelis privalo turėti daugiau nei :value reikšmių.',
+        'file' => ':attribute laukelis privalo būti didesnis už :value kilobaitų.',
+        'numeric' => ':attribute laukelis privalo būti didesnis už :value.',
+        'string' => ':attribute laukelis privalo būti didesnis už :value simbolių.',
+    ],
+    'gte' => [
+        'array' => ':attribute laukelis privalo turėti :value elementų ar daugiau.',
+        'file' => ':attribute laukelis privalo būti didesnis už arba lygus :value kilobaitams.',
+        'numeric' => ':attribute laukelis privalo būti didesnis už arba lygus :value.',
+        'string' => ':attribute laukelis privalo būti didesnis už arba lygus :value simbolių kiekiui.',
+    ],
+    'image' => ':attribute laukelis privalo būti nuotrauka.',
+    'in' => 'Pasirinktas :attribute yra netinkamas.',
+    'in_array' => ':attribute laukelis privalo egzistuoti :other.',
+    'integer' => ':attribute laukelis privalo būti sveikasis skaičius.',
+    'ip' => ':attribute laukelis privalo būti tinkamas IP adresas.',
+    'ipv4' => ':attribute laukelis privalo būti tinkamas IPv4 adresas.',
+    'ipv6' => ':attribute laukelis privalo būti tinkamas IPv6 adresas.',
+    'json' => ':attribute laukelis privalo būti tinkama JSON eilutė.',
+    'lowercase' => ':attribute laukelis privalo būti sudarytas iš mažųjų raidžių.',
+    'lt' => [
+        'array' => ':attribute laukelis privalo turėti mažiau nei :value elementų.',
+        'file' => ':attribute laukelis privalo būti mažesnis nei :value kilobaitų.',
+        'numeric' => ':attribute laukelis privalo būti mažesnis už :value.',
+        'string' => ':attribute laukelis privalo būti mažesnis už :value simbolių.',
+    ],
+    'lte' => [
+        'array' => ':attribute laukelis privalo neturėti daugiau už :value elementų.',
+        'file' => ':attribute laukelis privalo būti mažesnis už ar lygus :value kilobaitams.',
+        'numeric' => ':attribute laukelis privalo būti mažesnis už ar lygus :value.',
+        'string' => ':attribute laukelis privalo būti mažesnis už ar lygus :value simbolių kiekiui.',
+    ],
+    'mac_address' => ':attribute laukelis privalo būti tinkamas MAC adresas.',
+    'max' => [
+        'array' => ':attribute laukelis negali turėti daugiau nei :max elementų.',
+        'file' => ':attribute laukelis negali būti didesnis už :max kilobaitų.',
+        'numeric' => ':attribute laukelis negali būti didesnis už :max.',
+        'string' => ':attribute laukelis negali būti didesnis už :max simbolių kiekį.',
+    ],
+    'max_digits' => ':attribute laukelis negali turėti daugiau nei :max skaitmenų.',
+    'mimes' => ':attribute laukelis privalo būti failas, kurio rūšis: :values.',
+    'mimetypes' => ':attribute laukelis privalo būti failas, kurio rūšis: :values.',
+    'min' => [
+        'array' => ':attribute laukelis privalo turėti bent :min elementų.',
+        'file' => ':attribute laukelis privalo būti bent :min kilobaitų.',
+        'numeric' => ':attribute laukelis privalo būti bent :min.',
+        'string' => ':attribute laukelis privalo turėti bent :min simbolius.',
+    ],
+    'min_digits' => ':attribute laukelis privalo turėti bent :min skaitmenų.',
+    'missing' => ':attribute laukelis privalo būti tuščias.',
+    'missing_if' => ':attribute laukelis privalo būti tuščias kai :other yra :value.',
+    'missing_unless' => ':attribute laukelis privalo būti tuščias nebent :other yra :value.',
+    'missing_with' => ':attribute laukelis privalo būti tuščias kai egzistuoja :values.',
+    'missing_with_all' => ':attribute laukelis privalo būti tuščias kai egzistuoja :values.',
+    'multiple_of' => ':attribute laukelis privalo būti daugiklis iš :value.',
+    'not_in' => 'Pasirinktas :attribute yra netinkamas.',
+    'not_regex' => ':attribute laukelio formatas netinkamas.',
+    'numeric' => ':attribute laukelis privalo būti skaičius.',
+    'password' => [
+        'letters' => ':attribute laukelyje privalo būti bent viena raidė.',
+        'mixed' => ':attribute laukelyje privalo būti bent viena didžioji ir mažoji raidė.',
+        'numbers' => ':attribute laukelyje privalo būti bent vienas skaičius.',
+        'symbols' => ':attribute laukelyje privalo būti bent vienas simbolis.',
+        'uncompromised' => 'Įvestas :attribute jau yra nutekintas. Prašome pasirinkti kitą :attribute.',
+    ],
+    'present' => ':attribute laukelis privalo būti.',
+    'prohibited' => ':attribute laukelis yra draudžiamas.',
+    'prohibited_if' => ':attribute laukelis yra draudžiamas kai :other yra :value.',
+    'prohibited_unless' => ':attribute laukelis yra draudžiamas nebent :other yra tarp :values.',
+    'prohibits' => ':attribute laukelis neleidžia kad jame būtų :other.',
+    'regex' => ':attribute laukelio formatas netinkamas.',
+    'required' => ':attribute laukelis yra privalomas.',
+    'required_array_keys' => ':attribute laukelyje privalo būti įrašų iš: :values.',
+    'required_if' => ':attribute laukelis yra privalomas kai :other yra :value.',
+    'required_if_accepted' => ':attribute laukelis yra privalomas kai :other yra priimtas.',
+    'required_unless' => ':attribute laukelys yra privalomas nebent :other yra tarp :values.',
+    'required_with' => ':attribute laukelis yra privalomas kai yra :values.',
+    'required_with_all' => ':attribute laukelis yra privalomas kai yra :values reikšmės.',
+    'required_without' => ':attribute laukelis yra privalomas kai neegzistuoja :values.',
+    'required_without_all' => ':attribute laukelis yra privalomas kai egzistuoja nei vienas iš :values.',
+    'same' => ':attribute laukelis privalo sutapti su :other.',
+    'size' => [
+        'array' => ':attribute laukelyje privalo būti :size elementų.',
+        'file' => ':attribute laukelis privalo būti :size kilobaitų.',
+        'numeric' => ':attribute laukelis privalo būti :size.',
+        'string' => ':attribute laukelis privalo būti :size simbolių.',
+    ],
+    'starts_with' => ':attribute laukelis privalo prasidėti vienu iš: :values.',
+    'string' => ':attribute laukelis privalo būti tekstinis.',
+    'timezone' => ':attribute laukelis privalo būti tinkama laiko zona.',
+    'unique' => ':attribute jau yra užimtas.',
+    'uploaded' => 'Neišėjo įkelti :attribute.',
+    'uppercase' => ':attribute laukelis privalo būti sudarytas iš didžiųjų raidžių.',
+    'url' => ':attribute laukelis privalo būti tinkamas URL.',
+    'ulid' => ':attribute laukelis privalo būti tinkamas ULID.',
+    'uuid' => ':attribute laukelis privalo būti tinkamas UUID.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap our attribute placeholder
+    | with something more reader friendly such as "E-Mail Address" instead
+    | of "email". This simply helps us make our message more expressive.
+    |
+    */
+
+    'attributes' => [
+        'password' => 'Slaptažodis',
+    ],
+
+];

--- a/lang/lt/verify-email.php
+++ b/lang/lt/verify-email.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Add page Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'signup' => "Thanks for signing up! Before getting started, could you verify your 
+    email address by clicking on the link we just emailed to you? 
+    If you didn\'t receive the email, we will gladly send you another.",
+    'verlink' => 'A new verification link has been sent to the 
+    email address you provided during registration.',
+    'resend' => 'Resend Verification Email',
+    'logout' => 'Log Out',
+];

--- a/lang/lt/vote.php
+++ b/lang/lt/vote.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Vote Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'addvotes' => 'ADD YOUR VOTES',
+    'havevoted' => 'You have already voted',
+    'voteonall' => 'VOTE ON ALL THE',
+    'timesthat' => 'TIMES THAT SUIT YOU.',
+    'header' => 'Check every time you want to vote on and enter your name to
+    save your votes.',
+    'desctop' => 'Note: Name will be visible to everyone viewing this meeting.',
+    'descbot' => 'It is also recommended to use your real name so that meeting
+    creator knows who voted.',
+    'unavailable' => 'NO DATES AVAILABLE FOR VOTING',
+    'yourname' => 'YOUR NAME',
+    'voteon' => 'VOTE ON:',
+    'savevotes' => 'Save votes',
+];

--- a/lang/lt/welcome.php
+++ b/lang/lt/welcome.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Welcome Page Language lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'welcome_tab' => 'Welcome! • Timely',
+    'register' => 'Register',
+    'welcometo' => 'Welcome to',
+    'schedulingyour' => 'Scheduling your',
+    'meetings' => 'meetings',
+    'madeeasy' => 'made easy.',
+    'timelydesc' => 'Having trouble finding the meeting time that suits everyone? Look no further than your free,
+    open-source and privacy respecting solution - Timely',
+    'createfirst' => 'Create your first meeting',
+    'meetingheader' => 'Simple Meeting Page: Info, Times, and Easy Voting.',
+    'meetingdesc' => 'Simplify your meetings with our user-friendly Meeting Page! Find essential
+    details, including purpose, location, and duration. Send the meeting link to all your partners. Discover
+    available time slots and vote on your preferred time, bidding farewell to scheduling headaches!',
+    'calendarheader' => 'Effortless Date and Time Selection with Simple Calendar.',
+    'calendardesc' => "Our simple calendar feature is designed to take the hassle out of date and time
+    selection, making scheduling a breeze. We believe that managing your time should be easy and
+    stress-free, and that's why our user-friendly interface provides a seamless experience for all your
+    scheduling needs.",
+    'waste' => 'Waste',
+    'nomoretime' => 'No more time.',
+    'waste_upper' => "Just like our minimalist dashboard doesn't waste your time.",
+    'waste_lower' => "Make your step to effortless meeting scheduling.",
+    'getstarted' => 'Get started.',
+];

--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -1,6 +1,6 @@
 <x-guest-layout>
     <div class="mb-4 text-sm text-gray-600">
-        {{ __('This is a secure area of the application. Please confirm your password before continuing.') }}
+        {{ __('confirm-password.warning') }}
     </div>
 
     <form method="POST" action="{{ route('password.confirm') }}">
@@ -8,7 +8,7 @@
 
         <!-- Password -->
         <div>
-            <x-input-label for="password" :value="__('Password')" />
+            <x-input-label for="password" :value="__('confirm-password.passwd')" />
 
             <x-text-input id="password" class="block mt-1 w-full"
                             type="password"
@@ -20,7 +20,7 @@
 
         <div class="flex justify-end mt-4">
             <x-primary-button>
-                {{ __('Confirm') }}
+                {{ __('confirm-password.confirm') }}
             </x-primary-button>
         </div>
     </form>

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,6 +1,6 @@
 <x-guest-layout>
     <div class="mb-4 text-sm text-gray-600">
-        {{ __('Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.') }}
+        {{ __('forgot-password.forgot') }}
     </div>
 
     <!-- Session Status -->
@@ -11,14 +11,14 @@
 
         <!-- Email Address -->
         <div>
-            <x-input-label for="email" :value="__('Email')" />
+            <x-input-label for="email" :value="___('forgot-password.email')" />
             <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 
         <div class="flex items-center justify-end mt-4">
             <x-primary-button>
-                {{ __('Email Password Reset Link') }}
+                {{ __('forgot-password.send') }}
             </x-primary-button>
         </div>
     </form>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,5 +1,5 @@
 <x-guest-layout>
-    <body data-page-title="Login"></body>
+    <body data-page-title="{{ __('login.tab') }}"></body>
     <!-- Session Status -->
     <x-auth-session-status class="mb-4" :status="session('status')" />
 
@@ -7,14 +7,14 @@
         @csrf
 
         <div>
-            <x-input-label for="name" :value="__('USERNAME')" />
+            <x-input-label for="name" :value="__('login.name')" />
             <x-text-input id="name" class="block mt-1 w-full lowercase" type="text" name="name" :value="old('name')" required autofocus autocomplete="username" />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
 
         <!-- Password -->
         <div class="mt-4">
-            <x-input-label for="password" :value="__('PASSWORD')" />
+            <x-input-label for="password" :value="__('login.passwd')" />
 
             <x-text-input id="password" class="block mt-1 w-full"
                             type="password"
@@ -28,17 +28,17 @@
         <div class="block mt-4">
             <label for="remember_me" class="inline-flex items-center">
                 <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-purple-500 shadow-sm focus:ring-purple-700" name="remember">
-                <span class="ml-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
+                <span class="ml-2 text-sm text-gray-600">{{ __('login.remember') }}</span>
             </label>
         </div>
 
         <div class="flex items-center justify-end mt-4">
                 <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('register') }}">
-                    {{ __('Don\'t have an account yet?') }}
+                    {{ __('login.noacc') }}
                 </a>
 
             <x-primary-button class="ml-3">
-                {{ __('Log in') }}
+                {{ __('login.login') }}
             </x-primary-button>
         </div>
     </form>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -5,7 +5,7 @@
 
         <!-- Name -->
         <div>
-            <x-input-label for="name" :value="__('USERNAME')" />
+            <x-input-label for="name" :value="__('register.name')" />
             <x-text-input id="name" class="block mt-1 w-full lowercase" type="text" name="name" :value="old('name')" required autofocus autocomplete="username" />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
@@ -13,7 +13,7 @@
 
         <!-- Password -->
         <div class="mt-4">
-            <x-input-label for="password" :value="__('PASSWORD')" />
+            <x-input-label for="password" :value="__('register.passwd')" />
 
             <x-text-input id="password" class="block mt-1 w-full"
                             type="password"
@@ -25,7 +25,7 @@
 
         <!-- Confirm Password -->
         <div class="mt-4">
-            <x-input-label for="password_confirmation" :value="__('CONFIRM PASSWORD')" />
+            <x-input-label for="password_confirmation" :value="__('register.confirm')" />
 
             <x-text-input id="password_confirmation" class="block mt-1 w-full"
                             type="password"
@@ -36,11 +36,11 @@
 
         <div class="flex items-center justify-end mt-4">
             <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('login') }}">
-                {{ __('Already registered?') }}
+                {{ __('register.registered') }}
             </a>
 
             <x-primary-button class="ml-4">
-                {{ __('Register') }}
+                {{ __('register.register') }}
             </x-primary-button>
         </div>
     </form>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,5 +1,5 @@
 <x-guest-layout>
-    <body data-page-title="Register"></body>
+    <body data-page-title="{{ __('register.tab') }}"></body>
     <form method="POST" action="{{ route('register') }}">
         @csrf
 
@@ -41,10 +41,10 @@
                 <input type="checkbox" class="checkbox" name="terms" id="terms" required>
 
                 <div class="ml-2">
-                    I agree to the
-                    <a target="_blank" href="/terms-of-service" class="underline text-sm text-gray-600 hover:text-gray-900">Terms of Service</a>
-                    and
-                    <a target="_blank" href="/privacy-policy" class="underline text-sm text-gray-600 hover:text-gray-900">Privacy Policy</a>
+                    {{ __('register.agree') }}
+                    <a target="_blank" href="/terms-of-service" class="underline text-sm text-gray-600 hover:text-gray-900">{{ __('register.tos') }}</a>
+                    {{ __('register.and') }}
+                    <a target="_blank" href="/privacy-policy" class="underline text-sm text-gray-600 hover:text-gray-900">{{ __('register.policy') }}</a>
                 </div>
             </div>
         </div>

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -7,21 +7,21 @@
 
         <!-- Email Address -->
         <div>
-            <x-input-label for="email" :value="__('Email')" />
+            <x-input-label for="email" :value="__('reset-password.email')" />
             <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email', $request->email)" required autofocus autocomplete="username" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 
         <!-- Password -->
         <div class="mt-4">
-            <x-input-label for="password" :value="__('Password')" />
+            <x-input-label for="password" :value="__('reset-password.passwd')" />
             <x-text-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="new-password" />
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>
 
         <!-- Confirm Password -->
         <div class="mt-4">
-            <x-input-label for="password_confirmation" :value="__('Confirm Password')" />
+            <x-input-label for="password_confirmation" :value="__('reset-password.confirm')" />
 
             <x-text-input id="password_confirmation" class="block mt-1 w-full"
                                 type="password"
@@ -32,7 +32,7 @@
 
         <div class="flex items-center justify-end mt-4">
             <x-primary-button>
-                {{ __('Reset Password') }}
+                {{ __('reset-password.reset') }}
             </x-primary-button>
         </div>
     </form>

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -1,11 +1,11 @@
 <x-guest-layout>
     <div class="mb-4 text-sm text-gray-600">
-        {{ __('Thanks for signing up! Before getting started, could you verify your email address by clicking on the link we just emailed to you? If you didn\'t receive the email, we will gladly send you another.') }}
+        {{ __('verify-email.signup') }}
     </div>
 
     @if (session('status') == 'verification-link-sent')
         <div class="mb-4 font-medium text-sm text-green-600">
-            {{ __('A new verification link has been sent to the email address you provided during registration.') }}
+            {{ __('verify-email.verlink') }}
         </div>
     @endif
 
@@ -15,7 +15,7 @@
 
             <div>
                 <x-primary-button>
-                    {{ __('Resend Verification Email') }}
+                    {{ __('verify-email.resend') }}
                 </x-primary-button>
             </div>
         </form>
@@ -24,7 +24,7 @@
             @csrf
 
             <button type="submit" class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                {{ __('Log Out') }}
+                {{ __('verify-email.logout') }}
             </button>
         </form>
     </div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -10,16 +10,15 @@
 
     <div class="flex flex-col sm:justify-center items-center mt-8">
         <div>
-            <div class="fill-current text-black text-4xl font-bold">YOUR</div>
-            <div class="fill-current text-black text-4xl font-bold mb-8">MEETINGS.</div>
+            <div class="fill-current text-black text-4xl font-bold uppercase">{{ __('dashboard.your') }}</div>
+            <div class="fill-current text-black text-4xl font-bold uppercase mb-8">{{ __('dashboard.meetings') }}.</div>
         </div>
     </div>
     @if($meetings->isEmpty())
         <div class="flex justify-center items-center h-full">
-            <h2 class="text-2xl text-black font-bold">NO MEETINGS YET</h2>
+            <h2 class="text-2xl text-black font-bold uppercase">{{ __('dashboard.nomeetingsyet') }}</h2>
         </div>
-        <p class="flex justify-center items-center h-full text-xl mt-1 text-black font-bold">Create your first meeting
-            by pressing "Create a meeting" button</p>
+        <p class="flex justify-center items-center h-full text-xl mt-1 text-black font-bold">{{ __('dashboard.createfirstmeet') }}</p>
     @endif
     <div class="flex justify-center">
         <div

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -21,7 +21,7 @@
         <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">
             <div>
                 <a href="/">
-                    <div class="fill-current text-black text-4xl">WELCOME TO</div>
+                    <div class="fill-current text-black text-4xl">{{ __('guest.welcome') }}</div>
                     <div class="fill-current text-black text-8xl font-bold">Timely.</div>
                 </a>
             </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -5,7 +5,7 @@
         </div>
         <div class="flex justify-center sm:justify-end">
             <a href="/add-meeting" class="font-bold btn btn-ghost mx-4 sm:mx-6 text-xl flex items-center">
-                CREATE A MEETING
+                {{ __('navigation.create') }}
                 <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" class="bi bi-plus" viewBox="0 0 16 16">
                     <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"/>
                 </svg>
@@ -21,10 +21,10 @@
 
                     <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-gray-200 rounded-box w-40 sm:w-52 text-black">
                         <li>
-                            <a href="{{ route('profile.edit') }}">Profile</a>
+                            <a href="{{ route('profile.edit') }}">{{ __('navigation.profile') }}</a>
                         </li>
                         <li>
-                            <button type="submit">{{ __('Log Out') }}</button>
+                            <button type="submit">{{ __('navigation.logout') }}</button>
                         </li>
                     </ul>
                 </form>

--- a/resources/views/meetings/add.blade.php
+++ b/resources/views/meetings/add.blade.php
@@ -8,39 +8,37 @@
 
     <div class="flex flex-col sm:justify-center items-center mt-8">
         <div>
-            <div class="fill-current text-black text-4xl font-bold">CREATE A</div>
-            <div class="fill-current text-black text-4xl font-bold">NEW MEETING.</div>
+            <div class="fill-current text-black text-4xl font-bold">{{ __('add.create') }}</div>
+            <div class="fill-current text-black text-4xl font-bold">{{ __('add.new') }}</div>
         </div>
     </div>
-    <body data-page-title="Create a meeting"></body>
+    <body data-page-title="{{ __('add.tab_name') }}"></body>
     <x-slot name="header">
         <h2 class="text-xl text-black leading-tight">
-            Create a meeting
+            {{ __('add.tab_name') }}
         </h2>
     </x-slot>
     <x-meet-form-layout>
         <dialog id="my_modal_1" class="modal">
             <form method="dialog" class="modal-box bg-white shadow-xl">
                 <div class="modal-content">
-                    <h3 class="font-bold text-lg text-black flex justify-center mb-8">Which meeting type is right for
-                        me?</h3>
+                    <h3 class="font-bold text-lg text-black flex justify-center mb-8">{{ __('add.which') }}</h3>
                     <div class="flex flex-col lg:flex-col">
                         <div class="flex-1 text-black">
-                            <div class="font-bold text-xl uppercase">Group meeting.</div>
-                            <p>Choose group meeting if you need to find the meeting time that suits the most people</p>
+                            <div class="font-bold text-xl uppercase">{{ __('add.group') }}</div>
+                            <p>{{ __('add.group_expl') }}</p>
                         </div>
                         <div class="divider text-black flex items-center justify-center flex-1">
-                            OR
+                            {{ __('add.or') }}
                         </div>
                         <div class="flex-1 text-black">
-                            <div class="font-bold text-xl uppercase">1 on 1 meeting.</div>
-                            <p>Choose multiple times and allow participants to book the slot that best suits their
-                                schedule.</p>
+                            <div class="font-bold text-xl uppercase">{{ __('add.1v1') }}</div>
+                            <p>{{ __('add.1v1_expl') }}</p>
                         </div>
                     </div>
                     <div class="modal-action flex justify-center mt-4">
                         <button>
-                            <x-primary-button>Got it!</x-primary-button>
+                            <x-primary-button>{{ __('add.ok') }}</x-primary-button>
                         </button>
                     </div>
                 </div>
@@ -52,7 +50,7 @@
             @csrf
 
             <div class="tooltip tooltip-right" data-tip="Which to choose?">
-                <div class="font-bold text-md text-gray-700 inline-flex items-center">SELECT MEETING TYPE
+                <div class="font-bold text-md text-gray-700 inline-flex items-center">{{ __('add.select') }}
                     <span class="btn btn-ghost" onclick="my_modal_1.showModal()">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
                          xmlns="http://www.w3.org/2000/svg">
@@ -77,7 +75,7 @@
                                     d="M 28.0000 27.1257 C 31.1936 27.1257 33.9415 24.2737 33.9415 20.5602 C 33.9415 16.8912 31.1787 14.1729 28.0000 14.1729 C 24.8213 14.1729 22.0584 16.9506 22.0584 20.5898 C 22.0584 24.2737 24.8064 27.1257 28.0000 27.1257 Z M 10.9029 27.4673 C 13.6658 27.4673 16.0722 24.9718 16.0722 21.7485 C 16.0722 18.5548 13.6509 16.1930 10.9029 16.1930 C 8.1401 16.1930 5.7040 18.6143 5.7188 21.7782 C 5.7188 24.9718 8.1252 27.4673 10.9029 27.4673 Z M 45.0970 27.4673 C 47.8748 27.4673 50.2811 24.9718 50.2811 21.7782 C 50.2811 18.6143 47.8599 16.1930 45.0970 16.1930 C 42.3491 16.1930 39.9278 18.5548 39.9278 21.7485 C 39.9278 24.9718 42.3342 27.4673 45.0970 27.4673 Z M 2.6143 40.8806 L 13.9035 40.8806 C 12.3586 38.6376 14.2451 34.1220 17.4387 31.6562 C 15.7899 30.5570 13.6658 29.7400 10.8881 29.7400 C 4.1889 29.7400 0 34.6864 0 38.8010 C 0 40.1379 .7427 40.8806 2.6143 40.8806 Z M 53.3856 40.8806 C 55.2723 40.8806 56 40.1379 56 38.8010 C 56 34.6864 51.8113 29.7400 45.1119 29.7400 C 42.3342 29.7400 40.2102 30.5570 38.5613 31.6562 C 41.7549 34.1220 43.6414 38.6376 42.0966 40.8806 Z M 18.6568 40.8806 L 37.3283 40.8806 C 39.6604 40.8806 40.4925 40.2122 40.4925 38.9050 C 40.4925 35.0726 35.6944 29.7845 27.9851 29.7845 C 20.2907 29.7845 15.4928 35.0726 15.4928 38.9050 C 15.4928 40.2122 16.3247 40.8806 18.6568 40.8806 Z"/>
                             </svg>
                         </div>
-                        <div class="card-title">GROUP MEETING.</div>
+                        <div class="card-title uppercase">{{ __('add.group') }}</div>
                     </div>
                 </label>
                 <label class="card bg-white shadow-xl m-2 radio-label">
@@ -90,7 +88,7 @@
                                     d="M 28.0117 27.3672 C 33.0508 27.3672 37.3867 22.8672 37.3867 17.0078 C 37.3867 11.2187 33.0274 6.9297 28.0117 6.9297 C 22.9961 6.9297 18.6367 11.3125 18.6367 17.0547 C 18.6367 22.8672 22.9961 27.3672 28.0117 27.3672 Z M 13.2930 49.0703 L 42.7305 49.0703 C 46.4101 49.0703 47.7226 48.0156 47.7226 45.9531 C 47.7226 39.9062 40.1523 31.5625 28.0117 31.5625 C 15.8477 31.5625 8.2774 39.9062 8.2774 45.9531 C 8.2774 48.0156 9.5898 49.0703 13.2930 49.0703 Z"/>
                             </svg>
                         </div>
-                        <div class="card-title">1 ON 1 MEETING.</div>
+                        <div class="card-title uppercase">{{ __('add.1v1') }}</div>
                     </div>
                 </label>
             </div>
@@ -112,15 +110,15 @@
 
             <!-- Title -->
             <div>
-                <x-input-label for="title" :value="__('TITLE')"/>
+                <x-input-label for="title" :value="__('add.title')"/>
                 <x-text-input id="title" class="block mt-1 w-full text-black" type="text" name="title"
                               :value="old('title')"
-                              required autofocus autocomplete="title" maxlength="46" placeholder="Meeting Title"/>
+                              required autofocus autocomplete="title" maxlength="46" placeholder="{{ __('add.title_placeholder') }}"/>
                 <x-input-error :messages="$errors->get('title')" class="mt-2"/>
             </div>
             <!-- Description -->
             <div>
-                <x-input-label for="description" :value="__('DESCRIPTION')"/>
+                <x-input-label for="description" :value="__('add.desc')"/>
                 <x-textarea type="textarea" id="description" required autofocus autocomplete="description"
                             placeholder="Briefly describe what the meeting is about..." maxlength="1000"
                             name="description" class="text-black w-full">{{old('description')}}</x-textarea>
@@ -128,11 +126,11 @@
             </div>
             <!-- Location -->
             <div>
-                <x-input-label for="location" :value="__('LOCATION')"/>
+                <x-input-label for="location" :value="__('add.location')"/>
                 <x-text-input id="location"
                               class="block mt-1 w-full text-black"
                               type="text" name="location" :value="old('location')" required autofocus
-                              autocomplete="location" placeholder="Meeting Location (e.g., Conference Room A, Online)"
+                              autocomplete="location" placeholder="{{ __('add.location_placeholder') }}"
                               maxlength="50"/>
                 <x-input-error :messages="$errors->get('location')" class="mt-2"/>
             </div>
@@ -141,10 +139,10 @@
                 @php
                     $timezones = DateTimeZone::listIdentifiers(DateTimeZone::ALL);
                 @endphp
-                <x-input-label for="timezone" :value="__('TIMEZONE')"/>
+                <x-input-label for="timezone" :value="__('add.timezone')"/>
                 <select name="timezone" id="timezone" type="string"
                         class="border border-gray-300 text-black rounded-lg w-full mt-1 bg-white text-md focus:border-purple-500 focus:purple-500">
-                    <option value="default">Please select a timezone</option>
+                    <option value="default">{{ __('add.selecttimezone') }}</option>
                     @foreach($timezones as $timezone)
                         <option value="{{ $timezone }}">
                             {{ $timezone }}
@@ -157,31 +155,31 @@
             </div>
             <!-- Duration -->
             <div>
-                <x-input-label for="duration" :value="__('MEETING DURATION (MIN):')"/>
+                <x-input-label for="duration" :value="__('add.duration')"/>
                 <x-text-input type="smallInteger" id="duration"
                               class="block mt-1 w-full border border-gray-300 focus:border-purple-500 focus:purple-500 bg-white p-2 text-black"
                               type="string" name="duration" :value="old('duration')" required autofocus
-                              autocomplete="duration" placeholder="Estimated Meeting Duration"/>
+                              autocomplete="duration" placeholder="{{ __('add.duration_placeholder') }}"/>
                 <x-input-error :messages="$errors->get('duration')" class="mt-2"/>
             </div>
             <!-- Delete_after -->
             <div>
-                <x-input-label for="delete_after" :value="__('DELETE AFTER (DAYS) FROM CREATION:')"/>
+                <x-input-label for="delete_after" :value="__('add.delete_after')"/>
                 <x-text-input type="integer" id="delete_after"
                               class="block mt-1 w-full border border-gray-300 bg-white p-2 text-black"
                               type="string" name="delete_after" :value="old('delete_after')" required autofocus
-                              autocomplete="delete_after" placeholder="Choose time until deletion"/>
+                              autocomplete="delete_after" placeholder="{{ __('add.deletion_placeholder') }}"/>
                 <x-input-error :messages="$errors->get('delete_after')" class="mt-2"/>
             </div>
 
             <div class="flex items-center justify-end mt-4">
                 <a href="{{ route('dashboard') }}" tabindex="-1">
                     <x-secondary-button class="ml-4">
-                        Cancel
+                        {{ __('add.cancel') }}
                     </x-secondary-button>
                 </a>
                 <x-primary-button type="submit" class="ml-4">
-                    Create meeting
+                    {{ __('add.confirm') }}
                 </x-primary-button>
             </div>
     </x-meet-form-layout>

--- a/resources/views/meetings/confirm-delete.blade.php
+++ b/resources/views/meetings/confirm-delete.blade.php
@@ -2,8 +2,8 @@
     <body data-page-title="Confirm delete"></body>
     <div class="flex flex-col sm:justify-center items-center mt-8">
         <div>
-            <div class="fill-current text-black text-4xl font-bold">DELETE</div>
-            <div class="fill-current text-black text-4xl font-bold">MEETING.</div>
+            <div class="fill-current text-black text-4xl font-bold">{{ __('confirm-delete.delete') }}</div>
+            <div class="fill-current text-black text-4xl font-bold">{{ __('confirm-delete.meeting') }}</div>
         </div>
     </div>
     <x-meet-form-layout>
@@ -11,13 +11,13 @@
             @csrf
             @method('delete')
             <h2 class='text-2xl text-black font-bold uppercase'>{{ $meeting->title }}</h2><br>
-            <p class='text-red-700 uppercase'>Are you sure you want to delete this meeting?</p><br>
+            <p class='text-red-700 uppercase'>{{ __('confirm-delete.confirm') }}</p><br>
             <input type='hidden' name='id' value='{{ $meeting->id }}'>
 
             <a href="/meetings/{{ $meeting->id}}/">
-                <x-secondary-button>Cancel</x-secondary-button>
+                <x-secondary-button>{{ __('confirm-delete.cancel') }}</x-secondary-button>
             </a>
-            <x-danger-button>Confirm deletion</x-danger-button>
+            <x-danger-button>{{ __('confirm-delete.confirm-delete') }}</x-danger-button>
         </form>
     </x-meet-form-layout>
 </x-app-layout>

--- a/resources/views/meetings/edit-meeting-buttons.blade.php
+++ b/resources/views/meetings/edit-meeting-buttons.blade.php
@@ -1,8 +1,8 @@
 @if (Auth::check() && $meeting->user_id == Auth::User()->id)
     <a href='/meeting/{{ $meeting->id }}/edit'>
-        <x-secondary-button>Edit meeting and votes</x-secondary-button>
+        <x-secondary-button>{{ __('edit-meeting-buttons.edit') }}</x-secondary-button>
     </a>
     <a href='/meeting/{{ $meeting->id }}/delete'>
-        <x-danger-button>Delete meeting</x-danger-button>
+        <x-danger-button>{{ __('edit-meeting-buttons.delete') }}</x-danger-button>
     </a>
 @endif

--- a/resources/views/meetings/edit-meeting-buttons.blade.php
+++ b/resources/views/meetings/edit-meeting-buttons.blade.php
@@ -1,6 +1,6 @@
 @if (Auth::check() && $meeting->user_id == Auth::User()->id)
     <a href='{{ route('meetings.show-finalize-date', $meeting->id) }}'>
-        <x-secondary-button>Finalize a time</x-secondary-button>
+        <x-secondary-button>{{ __('edit-meeting-buttons.finalize') }}</x-secondary-button>
     </a>
 
     <a href='/meeting/{{ $meeting->id }}/edit'>

--- a/resources/views/meetings/edit-times.blade.php
+++ b/resources/views/meetings/edit-times.blade.php
@@ -2,7 +2,7 @@
     <details class="collapse bg-white mb-6">
         <summary class="collapse-title text-xl font-bold text-center">
             <div class="flex items-center justify-center">
-                <div class="btn btn-ghost text-xl font-bold shadow-lg">ADD TIMES
+                <div class="btn btn-ghost text-xl font-bold shadow-lg">{{ __('edit-times.times') }}
                     <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor"
                          class="bi bi-plus" viewBox="0 0 16 16">
                         <path
@@ -19,14 +19,14 @@
                 <input type='hidden' name='meeting_id' value='{{$meeting->id}}'>
                 <div class="mt-4 flex items-center space-x-2">
                     <div class="mb-2">
-                        <x-input-label for="new_time" :value="__('SELECT A NEW TIME')"/>
+                        <x-input-label for="new_time" :value="__('edit-times.select')"/>
                         <x-flatpickr name='new_time' show-time :min-date="now()->addMinutes(30)"
                                      :max-date="today()->addDays(90)" required/>
                         <x-input-error :messages="$errors->get('new_time')" class="mt-2"/>
                     </div>
                     <div class="mt-2.5">
                         <x-primary-button>
-                            {{ __('Add time') }}
+                            {{ __('edit-times.addtime') }}
                         </x-primary-button>
                     </div>
                 </div>

--- a/resources/views/meetings/edit-votes.blade.php
+++ b/resources/views/meetings/edit-votes.blade.php
@@ -1,13 +1,13 @@
 <details class="collapse bg-white">
-    <summary class="collapse-title text-xl text-black font-bold uppercase hover:bg-gray-300">Click here to edit votes
+    <summary class="collapse-title text-xl text-black font-bold uppercase hover:bg-gray-300">{{ __('edit-votes.clickhere') }}
     </summary>
     @if($meeting->dates->isNotEmpty())
     <div class="collapse-content">
-        <div class="uppercase font-bold text-black my-4">Select a time to edit votes:</div>
+        <div class="uppercase font-bold text-black my-4">{{ __('edit-votes.select') }}</div>
 
         @foreach($meeting->dates as $date)
             <details class="collapse bg-white hover:bg-gray-200">
-                <summary class="collapse-title text-xl text-black font-medium">Date and Time:
+                <summary class="collapse-title text-xl text-black font-medium">{{ __('edit-votes.date') }}
                     <div>{{ $date->date_and_time }}</div>
                 </summary>
 
@@ -20,7 +20,7 @@
                                 @csrf
                                 @method('put')
                                 <div class="mb-2">
-                                    <x-input-label for="voted_by_{{ $vote->id }}" :value="__('EDIT VOTE NAME')"/>
+                                    <x-input-label for="voted_by_{{ $vote->id }}" :value="__('edit-votes.editname')"/>
                                     <x-text-input id="voted_by_{{ $vote->id }}" class="block mt-1 w-full text-black"
                                                   type="text"
                                                   name="voted_by" required maxlength="46"
@@ -28,19 +28,19 @@
                                     <x-input-error :messages="$errors->get('voted_by')" class="mt-2"/>
                                 </div>
                                 <div>
-                                    <x-primary-button type="submit" class="ml-2 mt-2.5  ">Save</x-primary-button>
+                                    <x-primary-button type="submit" class="ml-2 mt-2.5  ">{{ __('edit-votes.save') }}</x-primary-button>
                                 </div>
                             </form>
                             <form method="post" action="{{ route('vote.destroy', $vote->id) }}">
                                 @csrf
                                 @method('delete')
-                                <x-danger-button type="submit">Delete vote</x-danger-button>
+                                <x-danger-button type="submit">{{ __('edit-votes.delete') }}</x-danger-button>
                             </form>
                         </div>
                     @endforeach
                 </div>
                 @else
-                    <div class="text-md font-bold text-red-600 flex justify-center uppercase">No votes on this date</div>
+                    <div class="text-md font-bold text-red-600 flex justify-center uppercase">{{ __('edit-votes.novotes') }}</div>
                 @endif
 
 
@@ -49,6 +49,6 @@
         @endforeach
     </div>
     @else
-    <div class="text-lg font-bold text-red-600 flex justify-center uppercase">No dates exist for this meeting</div>
+    <div class="text-lg font-bold text-red-600 flex justify-center uppercase">{{ __('edit-votes.nodates') }}</div>
     @endif
 </details>

--- a/resources/views/meetings/edit.blade.php
+++ b/resources/views/meetings/edit.blade.php
@@ -9,8 +9,8 @@
     <body data-page-title="Edit meeting"></body>
     <div class="flex flex-col sm:justify-center items-center mt-8">
         <div>
-            <div class="fill-current text-black text-4xl font-bold">EDIT A</div>
-            <div class="fill-current text-black text-4xl font-bold">MEETING.</div>
+            <div class="fill-current text-black text-4xl font-bold">{{ __('edit-meeting.edita') }}</div>
+            <div class="fill-current text-black text-4xl font-bold">{{ __('edit-meeting.meeting') }}</div>
         </div>
     </div>
     <x-meet-form-layout>
@@ -26,26 +26,26 @@
             @endphp
                 <!-- Title -->
             <div>
-                <x-input-label for="title" :value="__('TITLE')"/>
+                <x-input-label for="title" :value="__('edit-meeting.title')"/>
                 <x-text-input id="title" class="block mt-1 w-full text-black" type="text" name="title"
                               :value="$title"
-                              required autofocus autocomplete="title" maxlength="46" placeholder="Meeting Title"/>
+                              required autofocus autocomplete="title" maxlength="46" placeholder="{{ __('edit-meeting.title_placeholder') }}"/>
                 <x-input-error :messages="$errors->get('title')" class="mt-2"/>
             </div>
             <!-- Description -->
             <div>
-                <x-input-label for="description" :value="__('Description')"/>
+                <x-input-label for="description" :value="__('edit-meeting.desc')"/>
                 <x-textarea type="textarea" id="description" required autofocus autocomplete="description"
                             name="description" maxlength="1000">{{ $desc }}</x-textarea>
                 <x-input-error :messages="$errors->get('description')" class="mt-2"/>
             </div>
             <!-- Location -->
             <div>
-                <x-input-label for="location" :value="__('LOCATION')"/>
+                <x-input-label for="location" :value="__('edit-meeting.location')"/>
                 <x-text-input id="location"
                               class="block mt-1 w-full text-black"
                               type="text" name="location" :value="$location" required autofocus
-                              autocomplete="location" placeholder="Meeting Location (e.g., Conference Room A, Online)"
+                              autocomplete="location" placeholder="{{ __('edit-meeting.location_placeholder') }}"
                               maxlength="50"/>
                 <x-input-error :messages="$errors->get('location')" class="mt-2"/>
             </div>
@@ -54,10 +54,10 @@
                 @php
                     $timezones = DateTimeZone::listIdentifiers(DateTimeZone::ALL);
                 @endphp
-                <x-input-label for="timezone" :value="__('TIMEZONE')"/>
+                <x-input-label for="timezone" :value="__('edit-meeting.timezone')"/>
                 <select name="timezone" id="timezone" type="string"
                         class="border border-gray-300 text-black rounded-lg w-full mt-1 bg-white text-md focus:border-purple-500 focus:purple-500">
-                    <option value="default">Please select a timezone</option>
+                    <option value="default">{{ __('edit-meeting.selecttimezone') }}</option>
                     @foreach($timezones as $timezone)
                         <option value="{{ $timezone }}">
                             {{ $timezone }}
@@ -65,25 +65,25 @@
                     @endforeach
                 </select>
                 @error('timezone')
-                <p class="text-red-500 text-sm">{{ "Timezone must be selected." }}</p>
+                <p class="text-red-500 text-sm">{{ __('edit-meeting.mustselect') }}</p>
                 @enderror
             </div>
             <!-- Duration -->
             <div>
-                <x-input-label for="duration" :value="__('MEETING DURATION (MIN):')"/>
+                <x-input-label for="duration" :value="__('edit-meeting.duration')"/>
                 <x-text-input type="smallInteger" id="duration"
                               class="block mt-1 w-full border border-gray-300 focus:border-purple-500 focus:purple-500 bg-white p-2 text-black"
                               type="string" name="duration" :value="$duration" required autofocus
-                              autocomplete="duration" placeholder="Estimated Meeting Duration"/>
+                              autocomplete="duration" placeholder="{{ __('edit-meeting.duration_placeholder') }}"/>
                 <x-input-error :messages="$errors->get('duration')" class="mt-2"/>
             </div>
             <!-- Delete_after -->
             <div>
-                <x-input-label for="delete_after" :value="__('DELETE AFTER (DAYS) FROM CREATION:')"/>
+                <x-input-label for="delete_after" :value="__('edit-meeting.delete_after')"/>
                 <x-text-input type="integer" id="delete_after"
                               class="block mt-1 w-full border border-gray-300 bg-white p-2 text-black"
                               type="string" name="delete_after" :value="$delete_after" required autofocus
-                              autocomplete="delete_after" placeholder="Choose time until deletion"/>
+                              autocomplete="delete_after" placeholder="{{ __('edit-meeting.deletion_placeholder') }}"/>
                 <x-input-error :messages="$errors->get('delete_after')" class="mt-2"/>
             </div>
 
@@ -93,11 +93,11 @@
             <div class="flex items-center justify-end my-4">
                 <a href="/meetings/{{ $meeting->id }}   " tabindex="-1">
                     <x-secondary-button class="mr-2">
-                        Cancel
+                        {{ __('edit-meeting.cancel') }}
                     </x-secondary-button>
                 </a>
                 <x-primary-button>
-                    update meeting
+                    {{ __('edit-meeting.update') }}
                 </x-primary-button>
             </div>
         </form>

--- a/resources/views/meetings/meeting-cards.blade.php
+++ b/resources/views/meetings/meeting-cards.blade.php
@@ -10,7 +10,7 @@
                 <input type="hidden" name="meeting_id" value="{{ $meeting->id }}">
                 <div class="flex justify-between">
                     @if ($date->votes->count() > 0 && $date->votes->count() === $highestVoteCount)
-                        <div class="badge badge-outline text-purple-500 outline-purple-500 mt-3">Most voted</div>
+                        <div class="badge badge-outline text-purple-500 outline-purple-500 mt-3">{{ __('meeting-cards.mostvoted') }}</div>
                     @else
                         <div class="badge badge-outline outline-none border-none mt-3"></div>
                     @endif
@@ -31,7 +31,7 @@
                                 <a id="openDialog" class="" onclick="openModal(event)">
                                     <ul tabindex="0"
                                         class="dropdown-content bg-gray-100 rounded-box p-4 hover:bg-gray-200">
-                                        Delete
+                                        {{ __('meeting-cards.delete') }}
                                     </ul>
                                 </a>
                             </div>
@@ -40,12 +40,12 @@
                              class="fixed hidden z-40 w-screen h-screen inset-0 bg-gray-900 bg-opacity-60"></div>
                         <div id="dialog"
                              class="hidden fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-96 bg-white rounded-md px-8 py-6 space-y-5 drop-shadow-lg">
-                            <h1 class="text-2xl font-bold uppercase">Confirm Deletion.</h1>
-                            <p class="text-red-700">Are you sure you want to delete this date?</p>
+                            <h1 class="text-2xl font-bold uppercase">{{ __('meeting-cards.confirm') }}</h1>
+                            <p class="text-red-700">{{ __('meeting-cards.confirm_message') }}</p>
                             <div class="flex justify-end">
-                                <x-secondary-button class="m-1" id="closeDialog" onclick="closeModal()">Cancel
+                                <x-secondary-button class="m-1" id="closeDialog" onclick="closeModal()">{{ __('meeting-cards.cancel') }}
                                 </x-secondary-button>
-                                <x-danger-button class="m-1" onclick="confirmDelete()">Confirm Delete</x-danger-button>
+                                <x-danger-button class="m-1" onclick="confirmDelete()">{{ __('meeting-cards.confirmdelete') }}</x-danger-button>
                             </div>
                         </div>
                     @endif
@@ -70,27 +70,27 @@
 
                 <a href="{{ route('export.ics', $date) }}"
                    class="text-black flex justify-center hover:bg-gray-300 mt-2 btn btn-ghost">
-                    Export to calendar
+                   {{ __('meeting-cards.export') }}
                 </a>
                 <div class="font-bold text-xl flex justify-center mt-4"></div>
                 <div class="flex justify-center text-black text-3xl font-bold">
                     @if ($meeting->is1v1 === 0)
-                        Votes: {{ $date->votes->count() }}
+                    {{ __('meeting-cards.votes') }} {{ $date->votes->count() }}
                     @elseif ($meeting->is1v1 === 1 && $isDateTaken)
-                        TAKEN.
+                    {{ __('meeting-cards.taken') }}
                     @else
-                        FREE.
+                    {{ __('meeting-cards.free') }}
                     @endif
                 </div>
                 <div class="flex justify-center">
                     <div class="flex flex-col md:flex-row md:justify-between md:items-center">
                         <details class="collapse collapse-arrow bg-white hover:bg-gray-300 my-2 md:my-0 md:w-1/2">
-                            <summary class="collapse-title text-md font-bold">CLICK TO SEE WHO VOTED</summary>
+                            <summary class="collapse-title text-md font-bold">{{ __('meeting-cards.seewho') }}</summary>
                             <div class="collapse-content px-4 md:px-6">
                                 @if ($date->votes->isEmpty())
-                                    <div class="font-bold">NO VOTES ON THIS DATE</div>
+                                    <div class="font-bold">{{ __('meeting-cards.novotes') }}</div>
                                 @else
-                                    <div class="font-bold mb-2 md:mb-4">PEOPLE WHO VOTED:</div>
+                                    <div class="font-bold mb-2 md:mb-4">{{ __('meeting-cards.whovoted') }}</div>
                                     @foreach ($date->votes as $vote)
                                         <div class="mb-1">{{ $vote->voted_by }}</div>
                                     @endforeach

--- a/resources/views/meetings/meeting-info.blade.php
+++ b/resources/views/meetings/meeting-info.blade.php
@@ -1,6 +1,6 @@
 <div class="bg-white p-4">
     <div class="text-3xl font-bold text-black uppercase mb-4">{{ $meeting->title }}</div>
-    <div class="text-lg font-bold text-black uppercase mb-4">Meeting created by {{$creator->name}}</div>
+    <div class="text-lg font-bold text-black uppercase mb-4">{{ __('meeting-info.createdby') }} {{$creator->name}}</div>
 
     <div class="flex items-center mb-4">
         <div class="svg-container">
@@ -31,12 +31,12 @@
                     stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
         </div>
-        <div>{{ $meeting->duration }} minutes</div>
+        <div>{{ $meeting->duration }} {{ __('meeting-info.minutes') }}</div>
     </div>
 
-    <div class="font-bold pr-2 uppercase flex justify-center">Link to meeting:</div>
+    <div class="font-bold pr-2 uppercase flex justify-center">{{ __('meeting-info.link') }}</div>
     <div class="flex justify-center items-center mb-6">
-        <div class="tooltip mb-2" data-tip="Press the icon on the right to copy">
+        <div class="tooltip mb-2" data-tip="{{ __('meeting-info.data-tip') }}">
             <a class="link" id="link">https://timely.lt/meetings/{{ $meeting->id }}</a>
         </div>
         <a id="copyLink" class="btn-ghost rounded-lg">

--- a/resources/views/meetings/meeting.blade.php
+++ b/resources/views/meetings/meeting.blade.php
@@ -11,7 +11,7 @@
 
     <div class="flex flex-col sm:justify-center items-center mt-8">
         <div>
-            <div class="fill-current text-black text-4xl font-bold">MEETING.</div>
+            <div class="fill-current text-black text-4xl font-bold">{{ __('meeting.meeting') }}</div>
         </div>
     </div>
 
@@ -21,10 +21,10 @@
             @include('meetings.meeting-info')
 
 
-            <div class="flex justify-center text-xl font-bold"> DATES AND TIMES FOR THE MEETING:</div>
+            <div class="flex justify-center text-xl font-bold"> {{ __('meeting.dates') }}</div>
             <div class="flex justify-center text-xl mt-4">
                 @if($meeting->is1v1 == 1)
-                    Note: This meeting is 1 on 1, so only one vote per date is allowed.
+                    {{ __('meeting.1v1') }}
                 @endif
             </div>
 
@@ -39,16 +39,15 @@
             </div>
 
             <div class="flex justify-center items-center text-lg">
-                All times are in "{{$meeting->timezone}}" timezone
+                {{ __('meeting.timesarein') }} "{{$meeting->timezone}}" {{ __('meeting.timezone') }}
             </div>
 
             @if($meeting->dates->isEmpty())
                 <div class="flex justify-center items-center h-full mt-4">
-                    <h2 class="text-lg text-black font-bold">NO DATES YET</h2>
+                    <h2 class="text-lg text-black font-bold">{{ __('meeting.nodates') }}</h2>
                 </div>
                 @if(Auth::check())
-                    <p class="flex justify-center items-center h-full text-md mt-1 text-black font-bold">Add dates by
-                        using date selector above</p>
+                    <p class="flex justify-center items-center h-full text-md mt-1 text-black font-bold">{{ __('meeting.adddates') }}</p>
                 @endif
             @endif
 

--- a/resources/views/meetings/vote.blade.php
+++ b/resources/views/meetings/vote.blade.php
@@ -5,11 +5,11 @@
 @if (!$hasVoted)
     <button
         class="btn btn-outline border-none text-black text-xl shadow-lg hover:shadow-none"
-        onclick="votesModal.showModal()">ADD YOUR VOTES
+        onclick="votesModal.showModal()">{{ __('vote.addvotes') }}
     </button>
 @else
     <button class="btn btn-outline border-none text-black text-xl shadow-2xl" disabled="disabled">
-        <div class="text-gray-700">You have already voted</div>
+        <div class="text-gray-700">{{ __('vote.havevoted') }}</div>
     </button>
 @endif
 
@@ -26,20 +26,18 @@
         <input type="hidden" name="meeting_id" value="{{ $meeting->id }}">
         <div class="flex flex-col sm:justify-center items-center">
             <div>
-                <div class="fill-current text-black text-4xl font-bold">VOTE ON ALL THE</div>
-                <div class="fill-current text-black text-4xl font-bold mb-4">TIMES THAT SUIT YOU.</div>
+                <div class="fill-current text-black text-4xl font-bold">{{ __('vote.voteonall') }}</div>
+                <div class="fill-current text-black text-4xl font-bold mb-4">{{ __('vote.timesthat') }}</div>
             </div>
         </div>
-        <h3 class="font-bold text-lg text-black">Check every time you want to vote on and enter your name to
-            save your votes</h3>
-        <p class="py-4 text-black">Note: Name will be visible to everyone viewing this meeting.<br>
-            It is also recommended to use your real name so that meeting creator knows who voted.</p>
+        <h3 class="font-bold text-lg text-black">{{ __('vote.header') }}</h3>
+        <p class="py-4 text-black">{{ __('vote.desctop') }}<br>
+            {{ __('vote.descbot') }}</p>
         @if (count($meeting->dates) === 0)
-            <p class="text-red-700 text-xl font-bold flex justify-center mt-4">NO DATES AVAILABLE FOR
-                VOTING</p>
+            <p class="text-red-700 text-xl font-bold flex justify-center mt-4">{{ __('vote.unavailable') }}</p>
         @endif
         @if (count($meeting->dates) > 0)
-            <x-input-label for="voted_by" :value="__('YOUR NAME')"/>
+            <x-input-label for="voted_by" :value="__('vote.yourname')"/>
             <x-text-input
                 id="voted_by"
                 class="block mt-1 w-full text-black"
@@ -56,7 +54,7 @@
                 <div class="form-control">
                     <label class="label cursor-pointer">
                             <span
-                                class="label-text text-lg text-black font-bold">VOTE ON: {{$date->date_and_time}}</span>
+                                class="label-text text-lg text-black font-bold">{{ __('vote.voteon') }} {{$date->date_and_time}}</span>
                         <div class="shadow-xl">
                             @php
                                 $isDateTaken = \App\Models\Vote::where('date_id', $date->id)->exists();
@@ -75,7 +73,7 @@
             @endforeach
             <div class="flex items-center justify-end mt-4">
                 <x-primary-button type="submit" class="ml-4">
-                    {{ __('Save votes') }}
+                    {{ __('vote.savevotes') }}
                 </x-primary-button>
             </div>
         @endif

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,13 +1,13 @@
 <x-app-layout>
     <div class="flex flex-col sm:justify-center items-center mt-8">
         <div>
-            <div class="fill-current text-black text-4xl font-bold">PROFILE.</div>
+            <div class="fill-current text-black text-4xl font-bold uppercase"><h1>{{ __('edit.profile') }}</h1></div>
         </div>
     </div>
-    <body data-page-title="Profile"></body>
+    <body data-page-title={{ __('edit.profile_tab') }}></body>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Profile') }}
+            {{ __('edit.profile') }}
         </h2>
     </x-slot>
 

--- a/resources/views/profile/partials/delete-user-form.blade.php
+++ b/resources/views/profile/partials/delete-user-form.blade.php
@@ -1,18 +1,18 @@
 <section class="space-y-6">
     <header>
-        <h2 class="text-lg font-medium text-gray-900">
-            {{ __('DELETE ACCOUNT') }}
+        <h2 class="text-lg font-medium text-gray-900 uppercase">
+            {{ __('delete-user.deleteacc') }}
         </h2>
 
         <p class="mt-1 text-sm text-gray-600">
-            {{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.') }}
+            {{ __('delete-user.deletewarning') }}
         </p>
     </header>
 
     <x-danger-button
         x-data=""
         x-on:click.prevent="$dispatch('open-modal', 'confirm-user-deletion')"
-    >{{ __('Delete Account') }}</x-danger-button>
+    >{{ __('delete-user.deleteacc') }}</x-danger-button>
 
     <x-modal name="confirm-user-deletion" :show="$errors->userDeletion->isNotEmpty()" focusable>
         <form method="post" action="{{ route('profile.destroy') }}" class="p-6">
@@ -20,22 +20,22 @@
             @method('delete')
 
             <h2 class="text-lg font-medium text-gray-900">
-                {{ __('Are you sure you want to delete your account?') }}
+                {{ __('delete-user.deleteareyousure') }}
             </h2>
 
             <p class="mt-1 text-sm text-gray-600">
-                {{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.') }}
+                {{ __('delete-user.deleteconfirmwarn') }}
             </p>
 
             <div class="mt-6">
-                <x-input-label for="password" value="{{ __('Password') }}" class="sr-only" />
+                <x-input-label for="password" value="__('delete-user.password')" class="sr-only" />
 
                 <x-text-input
                     id="password"
                     name="password"
                     type="password"
                     class="mt-1 block w-3/4"
-                    placeholder="{{ __('Password') }}"
+                    placeholder="{{ __('delete-user.password') }}"
                 />
 
                 <x-input-error :messages="$errors->userDeletion->get('password')" class="mt-2" />
@@ -43,11 +43,11 @@
 
             <div class="mt-6 flex justify-end">
                 <x-secondary-button x-on:click="$dispatch('close')">
-                    {{ __('Cancel') }}
+                    {{ __('delete-user.cancel') }}
                 </x-secondary-button>
 
                 <x-danger-button class="ml-3">
-                    {{ __('Delete Account') }}
+                    {{ __('delete-user.deleteacc') }}
                 </x-danger-button>
             </div>
         </form>

--- a/resources/views/profile/partials/update-password-form.blade.php
+++ b/resources/views/profile/partials/update-password-form.blade.php
@@ -1,11 +1,11 @@
 <section>
     <header>
-        <h2 class="text-lg font-bold text-gray-900">
-            {{ __('UPDATE PASSWORD') }}
+        <h2 class="text-lg font-bold text-gray-900 uppercase">
+            {{ __('update-password.updatepas') }}
         </h2>
 
         <p class="mt-1 text-sm text-gray-600">
-            {{ __('Ensure your account is using a long, random password to stay secure.') }}
+            {{ __('update-password.ensure') }}
         </p>
     </header>
 
@@ -14,19 +14,19 @@
         @method('put')
 
         <div>
-            <x-input-label for="current_password" :value="__('CURRENT PASSWORD')" />
+            <x-input-label :value="__('update-password.curpassword')" for="current_password" />
             <x-text-input id="current_password" name="current_password" type="password" class="mt-1 block w-full" autocomplete="current-password" />
             <x-input-error :messages="$errors->updatePassword->get('current_password')" class="mt-2" />
         </div>
 
         <div>
-            <x-input-label for="password" :value="__('NEW PASSWORD')" />
+            <x-input-label for="password" :value="__('update-password.newpassword')" />
             <x-text-input id="password" name="password" type="password" class="mt-1 block w-full" autocomplete="new-password" />
             <x-input-error :messages="$errors->updatePassword->get('password')" class="mt-2" />
         </div>
 
         <div>
-            <x-input-label for="password_confirmation" :value="__('CONFIRM PASSWORD')" />
+            <x-input-label for="password_confirmation" :value="__('update-password.confirmpassword')" />
             <x-text-input id="password_confirmation" name="password_confirmation" type="password" class="mt-1 block w-full" autocomplete="new-password" />
             <x-input-error :messages="$errors->updatePassword->get('password_confirmation')" class="mt-2" />
         </div>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -1,11 +1,11 @@
 <section>
     <header>
         <h2 class="text-lg font-medium text-gray-900">
-            {{ __('Profile Information') }}
+            {{ __('update-profile-information.profileinfo') }}
         </h2>
 
         <p class="mt-1 text-sm text-gray-600">
-            {{ __("Update your account's profile information and email address.") }}
+            {{ __('update-profile-information.updateinfo') }}
         </p>
     </header>
 
@@ -18,29 +18,29 @@
         @method('patch')
 
         <div>
-            <x-input-label for="name" :value="__('Name')" />
+            <x-input-label for="name" :value="{{ __('update-profile-information.profileinfo') }}" />
             <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name', $user->name)" required autofocus autocomplete="name" />
             <x-input-error class="mt-2" :messages="$errors->get('name')" />
         </div>
 
         <div>
-            <x-input-label for="email" :value="__('Email')" />
+            <x-input-label for="email" :value="{{ __('update-profile-information.profilemail') }}" />
             <x-text-input id="email" name="email" type="email" class="mt-1 block w-full" :value="old('email', $user->email)" required autocomplete="username" />
             <x-input-error class="mt-2" :messages="$errors->get('email')" />
 
             @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && ! $user->hasVerifiedEmail())
                 <div>
                     <p class="text-sm mt-2 text-gray-800">
-                        {{ __('Your email address is unverified.') }}
+                        {{ __('update-profile-information.adressunverified') }}
 
                         <button form="send-verification" class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                            {{ __('Click here to re-send the verification email.') }}
+                            {{ __('update-profile-information.resendmail') }}
                         </button>
                     </p>
 
                     @if (session('status') === 'verification-link-sent')
                         <p class="mt-2 font-medium text-sm text-green-600">
-                            {{ __('A new verification link has been sent to your email address.') }}
+                            {{ __('update-profile-information.sendreset') }}
                         </p>
                     @endif
                 </div>
@@ -48,7 +48,7 @@
         </div>
 
         <div class="flex items-center gap-4">
-            <x-primary-button>{{ __('Save') }}</x-primary-button>
+            <x-primary-button>{{ __('update-profile-information.save') }}</x-primary-button>
 
             @if (session('status') === 'profile-updated')
                 <p
@@ -57,7 +57,7 @@
                     x-transition
                     x-init="setTimeout(() => show = false, 2000)"
                     class="text-sm text-gray-600"
-                >{{ __('Saved.') }}</p>
+                >{{ __('update-profile-information.saved') }}</p>
             @endif
         </div>
     </form>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Welcome! • Timely</title>
+    <body data-page-title={{ __('welcome.welcome_tab') }}></body>
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.bunny.net">
@@ -74,7 +74,7 @@
 
                     @if (Route::has('register'))
                         <a href="{{ route('register') }}"
-                           class="font-medium text-black uppercase btn-ghost p-6 rounded-xl">Register</a>
+                           class="font-medium text-black uppercase btn-ghost p-6 rounded-xl">{{ __('welcome.register') }}</a>
                     @endif
                 @endauth
             </div>
@@ -87,22 +87,21 @@
 
         <div class="w-full mx-auto text-left md:w-11/12 xl:w-9/12 md:text-center">
             <div class="mb-16">
-                <div class="fill-current text-black text-4xl">WELCOME TO</div>
+                <div class="fill-current text-black text-4xl uppercase">{{ __('welcome.welcometo') }}</div>
                 <div class="fill-current text-black text-8xl font-bold">Timely.</div>
             </div>
             <h1 class="mb-8 text-4xl font-extrabold leading-none tracking-normal text-gray-900 md:text-6xl md:tracking-tight">
-                <span>Scheduling your</span> <span
-                    class="block w-full py-2 text-transparent bg-clip-text leading-12 bg-gradient-to-r from-purple-950 to-purple-400 lg:inline">meetings</span>
-                <span>made easy.</span>
+                <span>{{ __('welcome.schedulingyour') }}</span> <span
+                    class="block w-full py-2 text-transparent bg-clip-text leading-12 bg-gradient-to-r from-purple-950 to-purple-400 lg:inline">{{ __('welcome.meetings') }}</span>
+                <span>{{ __('welcome.madeeasy') }}</span>
             </h1>
             <p class="px-0 mb-8 text-lg text-gray-600 md:text-xl lg:px-24">
-                Having trouble finding the meeting time that suits everyone? Look no further than your free,
-                open-source and privacy respecting solution - Timely
+                {{ __('welcome.timelydesc') }}
             </p>
             <div class="mb-4 space-x-0 md:space-x-2 md:mb-8">
                 <a href="{{ route('dashboard') }}"
                    class="inline-flex items-center justify-center w-full px-6 py-3 mb-2 btn btn-primary bg-purple-500 border-purple-500 sm:w-auto sm:mb-0">
-                    Create your first meeting
+                   {{ __('welcome.createfirst') }}
                     <svg class="w-4 h-4 ml-1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"
                          fill="currentColor">
                         <path fill-rule="evenodd"
@@ -147,13 +146,8 @@
             </div>
         </div>
         <div class="mt-28">
-            <h1 class="text-5xl font-bold text-black" data-aos="fade-left">Simple Meeting Page: Info, Times, and Easy
-                Voting.</h1>
-            <p class="py-6 text-black" data-aos="fade-up">Simplify your meetings with our user-friendly Meeting Page!
-                Find essential
-                details, including purpose, location, and duration. Send the meeting link to all your partners. Discover
-                available time slots and vote on your preferred time, bidding farewell to scheduling headaches!
-            </p>
+            <h1 class="text-5xl font-bold text-black" data-aos="fade-left">{{ __('welcome.meetingheader') }}</h1>
+            <p class="py-6 text-black" data-aos="fade-up">{{ __('welcome.meetingdesc') }}</p>
         </div>
     </div>
 </div>
@@ -163,13 +157,8 @@
         <img src="{{ asset('img/addtimes.png') }}" class="max-w-2xl rounded-lg shadow-2xl"
              alt="Meeting page" data-aos="fade-left"/>
         <div>
-            <h1 class="text-5xl font-bold text-black" data-aos="fade-right">Effortless Date and Time Selection with
-                Simple Calendar.</h1>
-            <p class="py-6 text-black" data-aos="fade-up">Our simple calendar feature is designed to take the hassle out
-                of date and time
-                selection, making scheduling a breeze. We believe that managing your time should be easy and
-                stress-free, and that's why our user-friendly interface provides a seamless experience for all your
-                scheduling needs.</p>
+            <h1 class="text-5xl font-bold text-black" data-aos="fade-right">{{ __('welcome.calendarheader') }}</h1>
+            <p class="py-6 text-black" data-aos="fade-up">{{ __('welcome.calendardesc') }}</p>
         </div>
     </div>
 </div>
@@ -180,16 +169,16 @@
 
         <div class="flex flex-col sm:justify-center items-center mt-8" data-aos="zoom-in">
             <div>
-                <div class="fill-current text-white text-6xl font-bold">WASTE</div>
-                <div class="fill-current text-white text-6xl font-bold mb-8">NO MORE TIME.</div>
+                <div class="fill-current text-white text-6xl font-bold uppercase">{{ __('welcome.waste') }}</div>
+                <div class="fill-current text-white text-6xl font-bold uppercase mb-8">{{ __('welcome.nomoretime') }}</div>
             </div>
         </div>
         <div class="max-w-md" data-aos="fade-left">
-            <p class="text-xl">Just like our minimalist dashboard doesn't waste your time.</p>
-            <p class="mb-5 text-2xl font-bold">Make your step to effortless meeting scheduling.</p>
+            <p class="text-xl">{{ __('welcome.waste_upper') }}</p>
+            <p class="mb-5 text-2xl font-bold">{{ __('welcome.waste_lower') }}</p>
             <div>
                 <a href="{{ route('dashboard') }}">
-                    <button class="btn btn-primary bg-purple-500 border-purple-500" data-aos="zoom-in">Get Started.</button>
+                    <button class="btn btn-primary bg-purple-500 border-purple-500" data-aos="zoom-in">{{ __('welcome.getstarted') }}</button>
                 </a>
             </div>
         </div>


### PR DESCRIPTION
Changed the text in every single view (that the user can see). Instead of the text being in the actual view, now it's in the newly created `lang` directory. This is where the localization files are stored. The view takes the text from these files. This will make it easier for any potential future translations, since now only the localization files will have to be changed/added. Plus it reduces the amount of text in the code itself, instead storing it elsewhere.

Also began translation to Lithuanian. Finished version will be in a separate issue/PR, along with Privacy policy and easter egg translations.