### PR TITLE
bug/404-when-finalizing-without-select

### DIFF
--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -114,6 +114,10 @@ class MeetingController extends Controller
             return redirect()->back()->with('error', 'Not authorized to finalize this date.');
         }
 
+        if ($meeting->dates->isEmpty()) {
+        return redirect()->route('meeting.show', $meeting->id)->with('error', 'Cannot finalize date. The meeting has no dates.');
+    }
+
         $selectedDateId = $request->input('selected_date');
         $meeting->dates()->update(['selected' => 0]);
 

--- a/resources/views/meetings/finalize-date.blade.php
+++ b/resources/views/meetings/finalize-date.blade.php
@@ -20,9 +20,10 @@
             @endphp
 
             <div class="mt-2">
-                @foreach($sortedDates as $dateOption)
+                @foreach($sortedDates as $index => $dateOption)
                 <label class="flex items-center mb-2">
-                    <input type="radio" name="selected_date" value="{{ $dateOption->id }}" class="mr-2 radio checked:bg-purple-500 radio-lg shadow-xl">
+                    <input type="radio" name="selected_date" value="{{ $dateOption->id }}" class="mr-2 radio checked:bg-purple-500 radio-lg shadow-xl"
+                    {{ $index === 0 ? 'checked' : '' }}>
                     <div class="text-black">{{ $dateOption->date_and_time }}</div>
                     <div class="ml-2 text-black uppercase">Votes: {{ $dateOption->votes->count() }}</div>
                 </label>


### PR DESCRIPTION
## Description

Fixed an issue which was caused by trying to finalize a date when there are no dates in the meeting. Also made the first option in finalization pre-selected (the one with most votes) to decrease the amount of clicks necessary.

## Changes Made

- Added an if statement in `app/Http/Controllers/MeetingController.php` which checks if the meeting has any dates. Throws an error and returns to meeting otherwise.
- Changed the loop in `resources/views/meetings/finalize-date.blade.php` so the first option becomes pre-selected.

## Related Issues

404 when finalizing without select #223 

## Checklist

- [x] Code works without errors or warnings
- [x] I have performed a self-review of my code
- [x] Coding style and guidelines have been followed
