### PR TITLE
feature/add-additional-error-to-login-page-to-display-that-the-password-is-incorrect

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -46,6 +46,7 @@ class LoginRequest extends FormRequest
 
             throw ValidationException::withMessages([
                 'name' => trans('auth.failed'),
+                'password' => trans('auth.password'),
             ]);
         }
 


### PR DESCRIPTION
## Description

Added an error message to the login page for passwords. Very super complex.

## Changes Made

- Added an additional message in `app/Http/Requests/Auth/LoginRequest.php`.

## Related Issues

Add additional error to login page to display that the password is incorrect #229 

## Checklist

- [x] Code works without errors or warnings
- [x] I have performed a self-review of my code
- [x] Coding style and guidelines have been followed
