### PR TITLE
Extract footer into a dedicated Blade component

### DIFF
--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,0 +1,14 @@
+<footer class="footer footer-center p-4 bg-white text-black">
+    <div>
+        <div class="flex items-center space-x-2">
+            <div class="text-black text-lg font-bold p-2">Timely</div>
+            <div class="text-sm p-2">v1.2.0-beta</div>
+            <div class="p-2">&copy; 2023 Kibernetiku klubas</div>
+            <div><a href="mailto:support@timely.lt" class="p-2 rounded-lg btn-ghost">support@timely.lt</a></div>
+        </div>
+        <div class="flex items-center space-x-2 mt-2">
+            <div>| <a href="/privacy-policy" target="_blank" class="p-2 rounded-lg btn-ghost">{{ __('app.privacy') }}</a> |</div>
+            <div><a href="https://github.com/kibernetiku-klubas/timely/blob/main/SECURITY.md" target="_blank" class="p-2 rounded-lg btn-ghost">{{ __('app.report') }}</a> |</div>
+        </div>
+    </div>
+</footer>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -26,20 +26,7 @@
         {{ $slot }}
     </main>
 </div>
-<footer class="footer footer-center p-4 bg-white text-black">
-    <div>
-        <div class="flex items-center space-x-2">
-            <div class="text-black text-lg font-bold p-2">Timely</div>
-            <div class="text-sm p-2">v1.1.1-beta</div>
-            <div class="p-2">&copy; 2023 Kibernetiku klubas</div>
-            <div><a href="mailto:support@timely.lt" class="p-2 rounded-lg btn-ghost">support@timely.lt</a></div>
-        </div>
-        <div class="flex items-center space-x-2 mt-2">
-            <div>| <a href="/privacy-policy" target="_blank" class="p-2 rounded-lg btn-ghost">{{ __('app.privacy') }}</a> |</div>
-            <div><a href="https://github.com/kibernetiku-klubas/timely/blob/main/SECURITY.md" target="_blank" class="p-2 rounded-lg btn-ghost">{{ __('app.report') }}</a> |</div>
-        </div>
-    </div>
-</footer>
+<x-footer></x-footer>
 
 </body>
 </html>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -191,24 +191,7 @@
         </div>
     </div>
 </div>
-<footer class="footer footer-center p-4 bg-white text-black">
-    <div>
-        <div class="flex items-center space-x-2">
-            <div class="text-black text-lg font-bold p-2">Timely</div>
-            <div class="text-sm p-2">v1.1.1-beta</div>
-            <div class="p-2">&copy; 2023 Kibernetiku klubas</div>
-            <div><a href="mailto:support@timely.lt" class="p-2 rounded-lg btn-ghost">support@timely.lt</a></div>
-        </div>
-        <div class="flex items-center space-x-2 mt-2">
-            <div>| <a href="/privacy-policy" target="_blank"
-                      class="p-2 rounded-lg btn-ghost">{{ __('welcome.privacy') }}</a> |
-            </div>
-            <div><a href="https://github.com/kibernetiku-klubas/timely/blob/main/SECURITY.md" target="_blank"
-                    class="p-2 rounded-lg btn-ghost">{{ __('welcome.report') }}</a> |
-            </div>
-        </div>
-    </div>
-</footer>
+<x-footer></x-footer>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
 <script>
     // Initialize AOS


### PR DESCRIPTION
The footer markup was repeated in both the welcome.blade.php and app.blade.php files. To adhere to the DRY (Don't Repeat Yourself) principle, the footer has been extracted into its own Blade component (footer.blade.php), which is now being referenced within the previously mentioned files. This change simplifies future updates and increases code readability.