### PR TITLE
Revise validation rule for user name length

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -31,7 +31,7 @@ class RegisteredUserController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'name' => ['required', 'string', 'max:255', 'unique:users,name,' . strtolower($request->input('name'))],
+            'name' => ['required', 'string', 'max:30', 'unique:users,name,' . strtolower($request->input('name'))],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -7,7 +7,7 @@
         <div>
             <x-input-label for="name" :value="__('register.name')" />
             <x-text-input id="name" class="block mt-1 w-full lowercase" type="text" name="name" :value="old('name')"
-                          required autofocus autocomplete="username" />
+                          required autofocus autocomplete="username" maxlength="30" />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
 


### PR DESCRIPTION
Reduced the maximum length of the user's name from 255 to 30 in the validation rule in RegisteredUserController. This change was also reflected in the register view by adding the maxlength attribute to the name input field.

This change was made to ensure consistency and prevent potential database constraints, as the User model is set to only accept names with a maximum of 30 characters.