### PR TITLE
Revise the meeting card title length

### DIFF
--- a/resources/views/components/meeting-card.blade.php
+++ b/resources/views/components/meeting-card.blade.php
@@ -2,7 +2,7 @@
     <div class="card bg-white hover:bg-gray-200 shadow-xl w-full h-full hover:shadow-lg rounded-lg p-4">
         <div class="card-body">
             <h2 class="card-title text-xl sm:text-2xl md:text-base lg:text-xl text-black">
-                {{ $meeting->title }}
+                {{ Str::limit($meeting->title, 25) }}
             </h2>
         </div>
     </div>


### PR DESCRIPTION
## Description

Applied limit to the length of the meeting title to maintain layout consistency and improve UI. A title that is too long could cause the card to stretch or display awkwardly on different devices. By limiting the title to 25 characters, we ensure the layout remains consistent regardless of the title length.

## Changes Made

Added Str::limit

## Related Issues

Fixes #244

## Checklist

<!-- A checklist of things that need to be verified before this PR can be considered for merging. -->

- [x] Code works without errors or warnings
- [x] I have performed a self-review of my code
- [x] Coding style and guidelines have been followed
