### PR TITLE
Fixed text overflowing in meeting page on mobile

### DIFF
--- a/resources/views/meetings/meeting-cards.blade.php
+++ b/resources/views/meetings/meeting-cards.blade.php
@@ -19,7 +19,7 @@
                             @endif
                         @endif
                     </div>
-                        
+
                    @if ($isUserCreator)
                         <form id="deleteForm{{ $date->id }}" method="POST"
                               action="{{ route('dates.destroy', ['id' => $date->id]) }}">
@@ -84,7 +84,7 @@
                     @elseif ($isDateTaken)
                         {{ __('meeting-cards.taken') }}
                     @else
-                        {{ __('meeting-cards.free') }} 
+                        {{ __('meeting-cards.free') }}
                     @endif
                 </div>
                 <div class="flex justify-center">
@@ -92,14 +92,14 @@
                         <details class="collapse collapse-arrow bg-white hover:bg-gray-300 my-2 md:my-0 md:w-1/2">
                             <summary class="collapse-title text-md font-bold">{{ __('meeting-cards.seewho') }}</summary>
                             <div class="collapse-content px-4 md:px-6">
-                                @if ($meeting->voter_invisible === 0 || ($meeting->voter_invisible === 1 
+                                @if ($meeting->voter_invisible === 0 || ($meeting->voter_invisible === 1
                                 && Auth::check() && $user->id == $meeting->user_id))
                                     @if ($date->votes->isEmpty())
                                         <div class="font-bold">{{ __('meeting-cards.novotes') }}</div>
                                     @else
                                         <div class="font-bold mb-2 md:mb-4">{{ __('meeting-cards.whovoted') }}</div>
                                         @foreach ($date->votes as $vote)
-                                            <div class="mb-1">{{ $vote->voted_by }}</div>
+                                            <div class="mb-1">{{ Str::limit($vote->voted_by, 25) }}</div>
                                         @endforeach
                                     @endif
                                 @else

--- a/resources/views/meetings/meeting-info.blade.php
+++ b/resources/views/meetings/meeting-info.blade.php
@@ -1,5 +1,5 @@
 <div class="bg-white p-4">
-    <div class="text-3xl font-bold text-black uppercase mb-4">{{ $meeting->title }}</div>
+    <div class="text-3xl font-bold text-black uppercase mb-4 break-all">{{ $meeting->title }}</div>
     <div class="text-lg font-bold text-black uppercase mb-4">{{ __('meeting-info.createdby') }} {{$creator->name}}</div>
 
     <div class="flex items-center mb-4">
@@ -9,7 +9,7 @@
                     d="M0,462h256v-64H0V462z M0,355.3h512v-64H0V355.3z M256,184.7H0v64h256V184.7z M0,78v64h512V78H0z"/>
             </svg>
         </div>
-        <div>{{ $meeting->description }}</div>
+        <div class="break-all">{{ $meeting->description }}</div>
     </div>
 
     <div class="flex items-center mb-4">
@@ -20,7 +20,7 @@
             C56,10.746,45.254,0,32,0z M32,32c-4.418,0-8-3.582-8-8s3.582-8,8-8s8,3.582,8,8S36.418,32,32,32z"/>
             </svg>
         </div>
-        <div>{{ $meeting->location }}</div>
+        <div class="break-all">{{ $meeting->location }}</div>
     </div>
 
     <div class="flex items-center mb-4">


### PR DESCRIPTION
## Description

Added break-all to title description and location. This will place the text that would overflow to a new line. Added a character limit on displaying voter names

## Related Issues

Fixes #270 

## Checklist


- [x] Code works without errors or warnings
- [x] I have performed a self-review of my code
- [x] Coding style and guidelines have been followed
