### PR TITLE
bug/users-can-vote-when-a-date-is-finalized

### DIFF
--- a/resources/views/meetings/meeting.blade.php
+++ b/resources/views/meetings/meeting.blade.php
@@ -32,10 +32,22 @@
             <div>
                     @if ($isUserCreator)
                         @include ('meetings.edit-times')
-                    @else
-                        <div class="flex justify-center my-8">
-                            @include('meetings.vote')
-                        </div>
+                        @else
+                            @php
+                                $dateSelected = false;
+                                foreach ($meeting->dates as $date) {
+                                    if ($date->selected == 1) {
+                                        $dateSelected = true;
+                                        break;
+                                    }
+                                }
+                            @endphp
+            
+                        @if ($dateSelected === false)
+                            <div class="flex justify-center my-8">
+                                @include('meetings.vote')
+                            </div>
+                        @endif
                     @endif
             </div>
             @else


### PR DESCRIPTION
## Description

Added a check in `resources/views/meetings/meeting.blade.php` which sees if the meeting has any finalized dates. If true, doesn't show the vote button. Very super complex.

## Changes Made

Added a foreach loop and if statement in `resources/views/meetings/meeting.blade.php`.

## Related Issues

Fixes #274 
