### PR TITLE
Fixed bad usernames breaking custom meeting links

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -31,7 +31,13 @@ class RegisteredUserController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'name' => ['required', 'string', 'max:30', 'unique:users,name,' . strtolower($request->input('name'))],
+            'name' => [
+                'required',
+                'string',
+                'max:30',
+                'unique:users,name,' . strtolower($request->input('name')),
+                'regex:/^[a-zA-Z0-9]+(?:\s[a-zA-Z0-9]+)*$/',
+            ],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 

--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -67,6 +67,10 @@ class MeetingController extends Controller
 
     public function showCustom($creator, $customUrl)
     {
+        // When passing data to route spaces are replaced with "-"
+        // So this is to replace them back to spaces
+        $creator = str_replace('-', ' ', $creator);
+
         $user = User::where('name', $creator)->firstOrFail();
 
         $meeting = Meeting::where('custom_url', $customUrl)

--- a/resources/views/components/meeting-card.blade.php
+++ b/resources/views/components/meeting-card.blade.php
@@ -1,5 +1,5 @@
 @if ($meeting->custom_url)
-    <a href='{{ route('meeting.show.custom', ['creator' => $meeting->creator->name, 'custom_url' => $meeting->custom_url])}}'
+    <a href='{{ route('meeting.show.custom', ['creator' => str_replace(' ', '-', $meeting->creator->name), 'custom_url' => $meeting->custom_url])}}'
        class="flex items-center justify-center h-full">
         @else
             <a href='/meetings/{{ $meeting->id }}' class="flex items-center justify-center h-full">


### PR DESCRIPTION
## Description

Fixed an issue where users could create a username that would break custom meeting links f.e. bad   username $%20   .  And replaced spaces with "-" in meeting link's creator name.

## Changes Made

- Change 1: Added new validation rules to names that now allow only letters a-z, numbers and maximum on 1 space between characters.
- Change 2: Replaced spaces with "-" in meeting link's creator name when passing data to route.