### PR TITLE
Removed delete after input

### DIFF
--- a/app/Http/Controllers/MeetingController.php
+++ b/app/Http/Controllers/MeetingController.php
@@ -47,9 +47,11 @@ class MeetingController extends Controller
 
         $validated = $request->validated();
 
-        if ($validated['delete_after'] < $validated['voting_deadline']) {
-            $validated['voting_deadline'] = 0;
-        }
+//        $validated['delete_after'] = 90;
+//
+//        if ($validated['delete_after'] < $validated['voting_deadline']) {
+//            $validated['voting_deadline'] = 0;
+//        }
 
         $meeting = new Meeting;
         $meeting->user_id = $user->id;
@@ -184,9 +186,9 @@ class MeetingController extends Controller
         $validated = $request->validated();
         $meeting = Meeting::where('user_id', Auth::user()->id)->findOrFail($id);
 
-        if ($validated['delete_after'] < $validated['voting_deadline']) {
-            $validated['voting_deadline'] = 0;
-        }
+//        if ($validated['delete_after'] < $validated['voting_deadline']) {
+//            $validated['voting_deadline'] = 0;
+//        }
 
         return $this->assignMeetingData($meeting, $validated, "meetings/$meeting->id");
     }
@@ -198,10 +200,10 @@ class MeetingController extends Controller
         $meeting->location = $validated['location'];
         $meeting->timezone = $validated['timezone'];
         $meeting->duration = $validated['duration'];
-        $meeting->delete_after = $validated['delete_after'];
+//        $meeting->delete_after = $validated['delete_after'];
         $meeting->is1v1 = $validated['is1v1'];
         $meeting->voter_invisible = 0;
-        $meeting->voting_deadline = $validated['voting_deadline'];
+//        $meeting->voting_deadline = $validated['voting_deadline'];
         $meeting->custom_url = $validated['custom_url'];
 
         if (isset($validated['voter_invisible']))

--- a/resources/views/meetings/add.blade.php
+++ b/resources/views/meetings/add.blade.php
@@ -165,15 +165,15 @@
                               autocomplete="duration" placeholder="{{ __('add.duration_placeholder') }}"/>
                 <x-input-error :messages="$errors->get('duration')" class="mt-2"/>
             </div>
-            <!-- Delete_after -->
-            <div>
-                <x-input-label for="delete_after" :value="__('add.delete_after')"/>
-                <x-text-input type="integer" id="delete_after"
-                              class="block mt-1 w-full border border-gray-300 bg-white p-2 text-black"
-                              type="string" name="delete_after" :value="old('delete_after')" required autofocus
-                              autocomplete="delete_after" placeholder="{{ __('add.deletion_placeholder') }}"/>
-                <x-input-error :messages="$errors->get('delete_after')" class="mt-2"/>
-            </div>
+{{--            <!-- Delete_after -->--}}
+{{--            <div>--}}
+{{--                <x-input-label for="delete_after" :value="__('add.delete_after')"/>--}}
+{{--                <x-text-input type="integer" id="delete_after"--}}
+{{--                              class="block mt-1 w-full border border-gray-300 bg-white p-2 text-black"--}}
+{{--                              type="string" name="delete_after" :value="old('delete_after')" required autofocus--}}
+{{--                              autocomplete="delete_after" placeholder="{{ __('add.deletion_placeholder') }}"/>--}}
+{{--                <x-input-error :messages="$errors->get('delete_after')" class="mt-2"/>--}}
+{{--            </div>--}}
             <!-- Advanced options -->
             <div>
                 <div class="font-bold text-md text-gray-700 inline-flex relative">
@@ -182,19 +182,24 @@
                             {{ __('add.advanced') }}
                         </x-input-label>
                         <div id="checkboxes" class="bg-white shadow-md rounded-lg p-2 space-y-2 hidden mt-2">
+
+{{--                            Invisible voters--}}
                             <x-input-label class="flex items-center space-x-2">
                                 <input type="checkbox" name="voter_invisible" value="1"
                                        class="form-checkbox text-purple-500" {{ old('voter_invisible') ? 'checked' : '' }}>
                                 <span>{{ __('add.voteinvis') }}</span>
                             </x-input-label>
-                            <x-input-label for="voting_deadline" :value="__('add.voting_deadline')"/>
-                            <x-text-input type="integer" id="voting_deadline"
-                                          class="block mt-1 w-full border border-gray-300 bg-white p-2 text-black"
-                                          type="string" name="voting_deadline" :value="old('voting_deadline', 0)"
-                                          required autofocus
-                                          autocomplete="voting_deadline" placeholder="{{ __('add.deadlinetext') }}"/>
-                            <x-input-error :messages="$errors->get('voting_deadline')" class="mt-2"/>
 
+{{--                            Voting Deadline--}}
+{{--                            <x-input-label for="voting_deadline" :value="__('add.voting_deadline')"/>--}}
+{{--                            <x-text-input type="integer" id="voting_deadline"--}}
+{{--                                          class="block mt-1 w-full border border-gray-300 bg-white p-2 text-black"--}}
+{{--                                          type="string" name="voting_deadline" :value="old('voting_deadline', 0)"--}}
+{{--                                          required autofocus--}}
+{{--                                          autocomplete="voting_deadline" placeholder="{{ __('add.deadlinetext') }}"/>--}}
+{{--                            <x-input-error :messages="$errors->get('voting_deadline')" class="mt-2"/>--}}
+
+{{--                            Custom link--}}
                             <x-input-label for="custom_url"
                                            :value="__('Enter a custom URL for a meeting (leave empty for default)')"/>
                             <x-text-input type="text" id="custom_url"
@@ -202,6 +207,7 @@
                                           name="custom_url" :value="old('custom_url')"
                                           placeholder="{{ __('Enter custom URL') }}" maxlength="46" />
                             <x-input-error :messages="$errors->get('custom_url')" class="mt-2"/>
+
                         </div>
                     </div>
                 </div>

--- a/resources/views/meetings/edit.blade.php
+++ b/resources/views/meetings/edit.blade.php
@@ -80,15 +80,15 @@
                               autocomplete="duration" placeholder="{{ __('edit-meeting.duration_placeholder') }}"/>
                 <x-input-error :messages="$errors->get('duration')" class="mt-2"/>
             </div>
-            <!-- Delete_after -->
-            <div>
-                <x-input-label for="delete_after" :value="__('edit-meeting.delete_after')"/>
-                <x-text-input type="integer" id="delete_after"
-                              class="block mt-1 w-full border border-gray-300 bg-white p-2 text-black"
-                              type="string" name="delete_after" :value="$delete_after" required autofocus
-                              autocomplete="delete_after" placeholder="{{ __('edit-meeting.deletion_placeholder') }}"/>
-                <x-input-error :messages="$errors->get('delete_after')" class="mt-2"/>
-            </div>
+{{--            <!-- Delete_after -->--}}
+{{--            <div>--}}
+{{--                <x-input-label for="delete_after" :value="__('edit-meeting.delete_after')"/>--}}
+{{--                <x-text-input type="integer" id="delete_after"--}}
+{{--                              class="block mt-1 w-full border border-gray-300 bg-white p-2 text-black"--}}
+{{--                              type="string" name="delete_after" :value="$delete_after" required autofocus--}}
+{{--                              autocomplete="delete_after" placeholder="{{ __('edit-meeting.deletion_placeholder') }}"/>--}}
+{{--                <x-input-error :messages="$errors->get('delete_after')" class="mt-2"/>--}}
+{{--            </div>--}}
             <!-- Advanced options -->
             <div>
                 <div class="font-bold text-md text-gray-700 inline-flex relative">
@@ -97,18 +97,24 @@
                             {{ __('edit-meeting.advanced') }}
                         </x-input-label>
                         <div id="checkboxes" class="bg-white shadow-md rounded-lg p-2 space-y-2 hidden mt-2">
+
+                            {{--                            Invisible voters--}}
                             <x-input-label class="flex items-center space-x-2">
                                 <input type="checkbox" name="voter_invisible" value="1"
                                        class="form-checkbox text-purple-500" {{ $meeting->voter_invisible ? 'checked' : '' }}>
                                 <span>{{ __('edit-meeting.voteinvis') }}</span>
                             </x-input-label>
-                            <x-input-label for="voting_deadline" :value="__('add.voting_deadline')"/>
-                            <x-text-input type="integer" id="voting_deadline"
-                                          class="block mt-1 w-full border border-gray-300 bg-white p-2 text-black"
-                                          type="string" name="voting_deadline" :value="$voting_deadline" required
-                                          autofocus
-                                          autocomplete="voting_deadline" placeholder="{{ __('add.deadlinetext') }}"/>
-                            <x-input-error :messages="$errors->get('voting_deadline')" class="mt-2"/>
+
+                            {{--                            Voting Deadline--}}
+{{--                            <x-input-label for="voting_deadline" :value="__('add.voting_deadline')"/>--}}
+{{--                            <x-text-input type="integer" id="voting_deadline"--}}
+{{--                                          class="block mt-1 w-full border border-gray-300 bg-white p-2 text-black"--}}
+{{--                                          type="string" name="voting_deadline" :value="$voting_deadline" required--}}
+{{--                                          autofocus--}}
+{{--                                          autocomplete="voting_deadline" placeholder="{{ __('add.deadlinetext') }}"/>--}}
+{{--                            <x-input-error :messages="$errors->get('voting_deadline')" class="mt-2"/>--}}
+
+                            {{--                            Custom link--}}
 
                             <x-input-label for="custom_url"
                                            :value="__('Enter a custom URL for a meeting (leave empty for default)')"/>

--- a/tests/Feature/MeetingTest.php
+++ b/tests/Feature/MeetingTest.php
@@ -21,10 +21,10 @@ class MeetingTest extends TestCase
             'location' => 'Test Location',
             'timezone' => 'Europe/Vilnius',
             'duration' => 60,
-            'delete_after' => 30,
+//            'delete_after' => 30,
             'is1v1' => 0,
             'voter_invisible' => 0,
-            'voting_deadline' => 5,
+//            'voting_deadline' => 5,
             'custom_url' => 'custom-meeting'
         ];
 
@@ -38,8 +38,8 @@ class MeetingTest extends TestCase
             'location' => $formData['location'],
             'timezone' => $formData['timezone'],
             'duration' => $formData['duration'],
-            'delete_after' => $formData['delete_after'],
-            'voting_deadline' => $formData['voting_deadline'],
+//            'delete_after' => $formData['delete_after'],
+//            'voting_deadline' => $formData['voting_deadline'],
             'custom_url' => $formData['custom_url'],
         ]);
     }


### PR DESCRIPTION
## Description

Commented out code, so that delete after and voting deadline (since it depends on delete after) options are hidden when creating meeting. Will add them back once they are ready. Now it is just an extra inconvenient step for user and does not give any result.

closes #291 