### PR TITLE
Fixed a major security flaw where users could delete or update other user's votes and create dates for other user's meetings

### DIFF
--- a/app/Http/Controllers/DateController.php
+++ b/app/Http/Controllers/DateController.php
@@ -18,6 +18,10 @@ class DateController extends Controller
         $validatedData = $request->validated();
         $meetingId = $request->input('meeting_id');
 
+        if (! $this->isUserMeetingCreator($meetingId)) {
+            return redirect()->back()->with('error', __('Not authorized'));
+        }
+
         $date = new Date;
         $date->meeting_id = $meetingId;
         $date->date_and_time = $validatedData['new_time'];

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -2,7 +2,7 @@
     <div>
         <div class="flex items-center space-x-2">
             <div class="text-black text-lg font-bold p-2">Timely</div>
-            <div class="text-sm p-2">v1.3.1-beta</div>
+            <div class="text-sm p-2">v1.3.2-beta</div>
             <div class="p-2">&copy; 2024 Kibernetiku klubas</div>
             <div><a href="mailto:support@timely.lt" class="p-2 rounded-lg btn-ghost">support@timely.lt</a></div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,9 +29,7 @@ Route::middleware('auth')->group(function () {
     Route::patch('/meeting/{id}/edit', [MeetingController::class, 'update'])->name('meetings.update');
     Route::view('/add-meeting', 'meetings.add');
 
-    Route::resource('dates', DateController::class);
     Route::post('/dates', [DateController::class, 'store'])->name('dates.store');
-    Route::put('/dates/{id}', [DateController::class, 'update'])->name('dates.update');
     Route::delete('/dates/{id}', [DateController::class, 'destroy'])->name('dates.destroy');
     Route::post('/meeting/{id}/finalize-date', [DateController::class, 'finalizeDate'])->name('dates.finalize-date');
     Route::get('/meeting/{id}/finalize-date', [DateController::class, 'showFinalizeDateView'])->name('dates.show-finalize-date-view');


### PR DESCRIPTION
## Description

Fixed a major security flaw where users could delete or update other user's votes and create dates for other user's meetings.

Not the cleanest solution, but this was urgent to fix. Will make it better in next refactoring.

Additionally fixed an issue with dates where going to /date/{id}/edit would cause 500 server error.